### PR TITLE
Add VNDA moat and industry/cycle specialist analyses

### DIFF
--- a/claude/VNDA/business-moat-analyst.md
+++ b/claude/VNDA/business-moat-analyst.md
@@ -1,0 +1,248 @@
+# Vanda Pharmaceuticals (VNDA) -- Business Quality & Moat Analysis
+
+**Date:** 2026-02-23
+**Market Cap:** ~$340M | Stock: ~$8/share (up ~40% on BYSANTI approval)
+**Analyst Mandate:** Durability-first, valuation-agnostic
+
+---
+
+## Business Model Summary (Economic, Not Narrative)
+
+Vanda Pharmaceuticals is a specialty pharma company that generates revenue from three marketed products, with two recently approved drugs not yet contributing materially:
+
+| Product | FY2025 Revenue | Indication | Status |
+|---------|---------------|------------|--------|
+| Fanapt (iloperidone) | $117.3M (+24% YoY) | Schizophrenia, Bipolar I | Patent settlements allow generics Nov 2027 or May 2028 |
+| HETLIOZ (tasimelteon) | $71.4M (-7% YoY) | Non-24 Sleep-Wake Disorder | Already facing generic erosion since 2022 |
+| PONVORY (ponesimod) | $27.4M (-2% YoY) | Multiple Sclerosis | Licensed from J&J, modest traction |
+| NEREUS (tradipitant) | $0 (pre-launch) | Motion Sickness | Approved Dec 2025, launch expected Q2-Q3 2026 |
+| BYSANTI (milsaperidone) | $0 (pre-launch) | Bipolar I, Schizophrenia | Approved Feb 2026, launch expected Q3 2026 |
+
+**Total FY2025 revenue: $216.1M. Net loss: $220.5M** (inflated by $113.7M non-cash deferred tax asset valuation allowance). Cash position: $263.8M at year-end 2025. 2026 guidance for existing products: $230M-$260M.
+
+**Who pays:** US commercial and government payors (Medicaid, Medicare, commercial insurance). Vanda sells directly through specialty pharmacies. The company runs a ~300-person Fanapt sales force and ~50 Ponvory specialty reps, roughly doubled from 160 Fanapt reps at end of 2024.
+
+**Cost structure:** High fixed costs (sales force, R&D, G&A) against a small revenue base. The company is currently burning cash: $29.9M decline in cash in Q4 2025 alone. Selling branded drugs to psychiatrists requires sustained commercial investment. The company is not profitable on a GAAP basis and is spending ahead of revenue to build commercial infrastructure for BYSANTI and NEREUS.
+
+**Where profits are generated:** Historically, profits came from Fanapt and HETLIOZ. HETLIOZ is in secular decline from generics. Fanapt is growing but faces its own generic cliff in late 2027/2028. The thesis rests almost entirely on whether BYSANTI can replace and expand upon Fanapt's revenue before generics arrive.
+
+---
+
+## Source(s) of Advantage
+
+### 1. Patent Protection on BYSANTI (Through 2044) -- The Stated Moat
+
+**Mechanism:** Milsaperidone (BYSANTI) is the active metabolite of iloperidone (Fanapt). Vanda obtained NCE (New Chemical Entity) status and separate patents by identifying and filing composition-of-matter claims on this metabolite. BYSANTI received 5-year regulatory data exclusivity and patents extending to 2044.
+
+**Why it matters:** This is a classic pharmaceutical "evergreening" strategy -- isolating the active metabolite of a drug approaching patent expiry and relaunching it as a new chemical entity with fresh IP protection. The most famous precedents are Claritin-to-Clarinex (loratadine to desloratadine) and Prilosec-to-Nexium (omeprazole to esomeprazole).
+
+**Why competitors cannot easily replicate:** The patents are issued and the NCE designation is granted. Generic firms would need to file their own ANDAs and Paragraph IV challenges against BYSANTI's patent estate, which extends to 2044. This creates a genuine legal barrier for approximately 18 years. No generic of milsaperidone can be approved and marketed without navigating this patent thicket.
+
+**Critical limitation:** Patent protection prevents generic milsaperidone, but it does NOT prevent competition from other branded antipsychotics, other generics (risperidone, quetiapine, aripiprazole, olanzapine), or novel mechanisms (Cobenfy). The patent protects against one specific form of competition -- a generic copy of the exact molecule -- while leaving the company exposed to therapeutic-class competition, which is the dominant force in this market.
+
+### 2. Switching Costs in Psychiatry -- Real but Nuanced
+
+**Mechanism:** In psychiatry, once a patient is stabilized on an antipsychotic, there is genuine clinical reluctance to switch. The literature is clear:
+
+- Nearly 25% of schizophrenia patients switch oral antipsychotics within the first year, with most switches occurring in the first 3 months ([JMCP 2024](https://www.jmcp.org/doi/10.18553/jmcp.2024.23274)).
+- Patients who switch incur ~$3,000 (25%) more in annual healthcare costs and utilize acute care services sooner ([JMCP 2024](https://www.jmcp.org/doi/10.18553/jmcp.2024.23274)).
+- Contraindications to switching include patients stable on their current regimen, those with history of self-harm, and those who have achieved symptom control ([Psychiatric Times](https://www.psychiatrictimes.com/view/switching-antipsychotics-why-when-and-how)).
+- Clinical guidelines recommend patients be stable for 3-6 months post-symptom resolution before any switch is considered.
+
+**Implications for BYSANTI:** This cuts both ways. Switching costs help retain patients already on BYSANTI. But switching costs also make it harder to ACQUIRE patients currently stabilized on generic iloperidone, aripiprazole, risperidone, or quetiapine. Vanda must capture patients at the point of initial prescribing or at treatment failure -- not by switching stable patients off generics.
+
+**Structural vs. behavioral retention:** The switching costs in psychiatry are primarily behavioral and clinical, not contractual or technical. There is no data lock-in, no integration cost, no workflow dependency. A psychiatrist can write a new prescription in 30 seconds. The barrier is clinical judgment and risk aversion, which is meaningful but not absolute.
+
+### 3. Bioequivalence Data Package -- Efficiency, Not Differentiation
+
+**Mechanism:** BYSANTI leverages the 100,000+ patient-years of safety data from iloperidone/Fanapt to support its label. This reduced development risk and cost for Vanda.
+
+**Why this is NOT a moat:** The bioequivalence data package is an asset for the FDA regulatory pathway, not a source of competitive advantage in the marketplace. Once approved, the drug must compete commercially on prescribing behavior, formulary placement, and payor willingness to reimburse. The bioequivalence to an existing (soon-to-be-generic) molecule is actually a commercial liability, not an advantage. Payors will ask: why should we pay branded prices for a drug that is bioequivalent to a generic?
+
+### 4. Potential LAI (Long-Acting Injectable) Formulation
+
+**Mechanism:** Vanda states that milsaperidone's physicochemical properties make it amenable to long-acting injectable development via lipid ester formulations.
+
+**Assessment:** This is speculative optionality, not a current advantage. No LAI formulation has been submitted to the FDA. No clinical data on an LAI exists. The LAI market for antipsychotics is well-established (aripiprazole, paliperidone, risperidone all have LAI versions), and entering it would require substantial additional investment. If Vanda develops an LAI, it could meaningfully differentiate BYSANTI from generic oral iloperidone. But this is a future possibility, not a present moat.
+
+---
+
+## Competitive Landscape
+
+### The Antipsychotic Market Is Brutally Competitive
+
+The US antipsychotic market (~$6.9B in 2024, projected ~$12.5B by 2034) is one of the most competitive therapeutic categories in all of pharma. BYSANTI enters a market with the following:
+
+**Dominant generics (70% of prescriptions):** Risperidone, quetiapine, aripiprazole, olanzapine -- all available as cheap generics. These are the standard of care by volume. Generic iloperidone is expected to enter the market in late 2027/2028 per settlement agreements with Taro and Apotex.
+
+**Scaled branded competitors:**
+- **Caplyta (lumateperone)** -- Now owned by J&J ($14.6B acquisition). 2024 revenue: $680M, projected $1B+ in 2025. Approved for schizophrenia, bipolar depression, and now MDD. J&J projects $5B peak sales. This is the 800-pound gorilla Vanda must compete against, backed by J&J's commercial firepower and broad-label positioning.
+- **Cobenfy (KarXT)** -- BMS's novel muscarinic receptor agonist, first new mechanism in schizophrenia in 35+ years. 2025 sales ~$166M in its first full year. Still early but represents genuine therapeutic innovation. BMS is pursuing label expansion into bipolar, Alzheimer's psychosis, and autism irritability.
+- **Rexulti (brexpiprazole)** -- Otsuka/Lundbeck. Well-established in schizophrenia and MDD augmentation. Growing rapidly.
+- **Lybalvi (olanzapine/samidorphan)** -- Alkermes. Differentiated by weight-mitigation profile vs. olanzapine alone.
+- **Vraylar (cariprazine)** -- AbbVie. 2023 sales: $2.7B. Dominant in bipolar and schizophrenia.
+- **Long-acting injectables** -- Multiple branded LAIs (aripiprazole, paliperidone) compete for the adherence-challenged patient population.
+
+**The critical competitive question:** If a psychiatrist is choosing a branded antipsychotic, why would they choose BYSANTI over Caplyta (broader label, massive data, J&J commercial backing), Cobenfy (novel mechanism, differentiated side effect profile), or Vraylar ($2.7B revenue, proven in bipolar)? BYSANTI's pharmacological profile is essentially identical to iloperidone -- a drug that, despite being on the market since 2009, never achieved more than low single-digit market share.
+
+**Historical context:** Fanapt/iloperidone has been available since 2009 but generated only $117.3M in 2025 sales -- after 16 years on the market and recent bipolar I label expansion. It holds a tiny fraction of the overall antipsychotic market. There is no evidence iloperidone's pharmacology has latent demand that simply needs a new brand name. BYSANTI is pharmacologically the same molecule in equilibrium.
+
+### Who Would Attack Vanda's Excess Returns?
+
+If BYSANTI generated excess returns:
+- **J&J (Caplyta):** Would compete on breadth of label (schizophrenia + bipolar depression + MDD) and sales force scale. J&J has vastly more commercial resources.
+- **BMS (Cobenfy):** Would compete on mechanism differentiation -- the only non-dopaminergic antipsychotic, with a genuinely novel value proposition for patients intolerant of traditional antipsychotics.
+- **Generic manufacturers:** Would compete on price, which they already do with generic quetiapine, risperidone, aripiprazole, and olanzapine. And with generic iloperidone arriving 2027-2028, the specific pharmacological profile of BYSANTI will be available generically, just under a different chemical name.
+- **PBMs and payors:** Would impose formulary restrictions (prior authorization, step therapy, non-preferred tier) to steer patients toward cheaper alternatives.
+
+---
+
+## Customer Behavior & Revenue Quality
+
+### Customer Concentration
+
+Vanda sells to psychiatrists in the US. The prescriber base is fragmented -- there are approximately 45,000 psychiatrists in the US. No single customer or group of customers represents an outsized share of revenue. However, the company relies heavily on specialty pharmacies for distribution, and inventory dynamics at these pharmacies have already impacted HETLIOZ quarterly results.
+
+### Retention and Churn
+
+Specific churn/retention data for Fanapt is not publicly disclosed. However, the broader antipsychotic literature suggests:
+- 50-80% of schizophrenia patients are non-adherent to oral antipsychotics over the course of a year.
+- 90.4% discontinuation rate for oral antipsychotics within one year in some studies.
+- Patients who do achieve stabilization on a specific agent tend to remain on it longer, but this is a minority of initial prescriptions.
+
+The high new-to-brand prescription growth for Fanapt (149% YoY, from ~40/week to ~240/week) is encouraging but from a very small base. This reflects the bipolar I label expansion and sales force investment more than organic pull-through from product differentiation.
+
+### Revenue Visibility
+
+Pharmaceutical revenue is inherently low-visibility on a per-patient basis but has some structural predictability:
+- Chronic conditions (schizophrenia, bipolar) require ongoing medication.
+- Prescription refills provide recurring revenue once a patient is started.
+- Formulary position provides some near-term visibility (payors typically update formularies annually).
+
+**But:** There are no long-term contracts. Formulary status can change. Prior authorization requirements can be imposed or removed. Revenue is entirely driven by prescription volume, which is subject to competitive dynamics, payor decisions, and prescriber behavior. This is *not* SaaS-like recurring revenue despite the chronic nature of the conditions.
+
+### Pricing Power
+
+**This is the critical weakness.** BYSANTI is bioequivalent to iloperidone. Generic iloperidone will be available by late 2027 or 2028 (per Taro/Apotex settlements), likely at 50-70% price reductions from branded Fanapt. Fanapt's current WAC is approximately $25-35/day (~$9,125-$12,775/year).
+
+Vanda must convince payors to reimburse BYSANTI at branded pricing when the identical pharmacological effect will be available as a generic. Historical precedent is unfavorable:
+
+- **Clarinex (desloratadine)** achieved only 0.3% market share in managed care plans that actively managed formularies, versus 7.9% national average. Payors aggressively steered patients to Claritin and generics.
+- **Nexium (esomeprazole)** succeeded commercially but largely due to massive marketing spend by AstraZeneca and before aggressive payor pushback became standard. Even so, generic omeprazole (Prilosec) remained the workhorse of the category.
+
+The psychiatric market is somewhat more protected from this dynamic than allergies or acid reflux because:
+1. The consequences of switching are higher (psychotic relapse vs. sneezing).
+2. Psychiatrists exercise more independent prescribing judgment.
+3. Schizophrenia patients on Medicaid face fewer formulary restrictions.
+
+But the broad trend is clear: payors will push back against branded pricing for bioequivalent drugs when cheaper alternatives exist. BYSANTI's pricing power is constrained from day one by the impending availability of generic iloperidone and by the existence of numerous other generic antipsychotics.
+
+---
+
+## Evidence of Moat in the Financials
+
+### Margin Stability
+
+Vanda is not profitable. The company posted a $220.5M net loss in FY2025 on $216.1M revenue. While ~$113.7M of this is a non-cash deferred tax asset write-down, the underlying business is cash-flow negative and spending to build commercial infrastructure.
+
+Historical margin trajectory on HETLIOZ demonstrates what happens when generics enter: revenue declined from ~$94.7M (2022) to $71.4M (2025), a 25% decline over three years. Vanda's own experience proves that branded products are not protected from generic erosion, even in niche therapeutic areas.
+
+Fanapt is currently growing (24% YoY), but this growth is driven by commercial investment (doubled sales force) and the bipolar I label expansion, not by structural moat. The question is whether this growth trajectory is sustainable or is being "rented" through sales force spend.
+
+### Returns on Invested Capital
+
+Cannot be meaningfully assessed given the company's current loss-making status. There is no historical track record of sustained high returns to suggest a structural competitive advantage.
+
+### Pricing Evidence
+
+No disclosed data on net price trends, rebating levels, or contract-vs-WAC pricing dynamics for Fanapt or BYSANTI. The fact that Vanda guided to Fanapt revenue of $150-170M for 2026 (vs. $117M in 2025) suggests continued growth, likely volume-driven rather than price-driven based on management commentary about prescription trends.
+
+---
+
+## Fragility Analysis (How the Moat Breaks)
+
+### Scenario 1: Payor Pushback on BYSANTI (HIGH PROBABILITY)
+
+PBMs and payors impose step therapy requiring patients to try generic iloperidone (available 2027-2028) before BYSANTI is reimbursed. This is the most likely scenario and the one with the greatest impact on BYSANTI's commercial potential. If payors classify BYSANTI as "therapeutically equivalent to generic iloperidone," it will be placed on unfavorable formulary tiers with significant prior authorization barriers.
+
+The Clarinex precedent is directly relevant. In managed care plans that actively managed formularies, Clarinex (the active metabolite of Claritin) achieved near-zero market share because payors simply said: "Use the generic parent drug instead."
+
+**Counterargument:** Psychiatry is somewhat different because of the clinical stakes and the Medicaid/Medicare patient population. But "somewhat different" is not "immune." And even if some patients are protected, the pricing differential between branded BYSANTI and generic iloperidone will be enormous.
+
+### Scenario 2: Generic Iloperidone Captures the Market Before BYSANTI Gains Traction (MODERATE-HIGH PROBABILITY)
+
+BYSANTI launches Q3 2026. Generic iloperidone enters late 2027 or May 2028. That gives Vanda approximately 15-21 months to establish BYSANTI before generic iloperidone becomes available. This is a very tight window. Psychiatrists who are now prescribing branded Fanapt for bipolar I will face intense payor pressure to switch to generic iloperidone -- which is bioequivalent to BYSANTI, which is bioequivalent to Fanapt. The circular pharmacology makes BYSANTI's commercial position inherently fragile.
+
+### Scenario 3: Cobenfy or Caplyta Captures the "Next-Generation" Positioning (MODERATE PROBABILITY)
+
+If psychiatrists want a branded antipsychotic with genuine differentiation, they have Cobenfy (novel mechanism) and Caplyta (broader label, J&J backing, clean metabolic profile). BYSANTI's pharmacology is the same as a 17-year-old drug. The "new brand, old molecule" positioning may not resonate with prescribers seeking actual innovation.
+
+### Scenario 4: Cash Burn Exceeds Revenue Growth (MODERATE PROBABILITY)
+
+With $263.8M in cash, a $220.5M net loss (even excluding the tax write-down, operating losses are material), and management declining to provide cash guidance while warning 2026 burn will exceed 2025 levels, there is execution risk around commercial ramp. If BYSANTI and NEREUS launches underperform, Vanda could face a capital constraint that limits commercial investment, creating a downward spiral.
+
+### Scenario 5: Treatment-Resistant Depression Trial Fails (BINARY RISK)
+
+The Phase 3 trial of BYSANTI as adjunct therapy for treatment-resistant MDD, with results expected end of 2026, is a significant pipeline catalyst. Failure would narrow BYSANTI's addressable market and remove a potential source of differentiation from generic iloperidone (which does NOT have a depression indication).
+
+### Weakest Point in the Business Model
+
+**The bioequivalence itself.** The very feature that enabled efficient FDA approval -- bioequivalence to iloperidone -- is the greatest commercial liability. It gives payors a direct and scientifically irrefutable reason to require generic iloperidone instead of branded BYSANTI. "Bioequivalent" literally means "same therapeutic effect." This is the central contradiction in the bull case.
+
+---
+
+## The One Thing That Matters for Durability
+
+**Formulary access and payor willingness to reimburse BYSANTI at branded pricing despite the availability of bioequivalent generic iloperidone.**
+
+Everything else is secondary. The patent protection through 2044 is irrelevant if payors refuse to cover BYSANTI at branded pricing when generic iloperidone costs 50-70% less and delivers the same pharmacological effect. The switching costs in psychiatry are irrelevant if new patients are never started on BYSANTI because step therapy requires generic iloperidone first. The sales force is irrelevant if prescriptions are reversed at the pharmacy counter by prior authorization denials.
+
+This single factor -- payor economics -- dominates all other competitive dynamics. If BYSANTI achieves preferred formulary status without step-through requirements, the business model works. If payors treat it as non-preferred or require step therapy through generic iloperidone, the business model is severely impaired.
+
+**What would strengthen this factor:** A successful MDD indication (not available for generic iloperidone), an LAI formulation (long-acting injectable, also not available for generic iloperidone), or clinically meaningful differentiation data that generic iloperidone cannot claim. These would give payors a reason to differentiate BYSANTI from generic iloperidone.
+
+**What would weaken this factor:** Entry of generic iloperidone in 2027-2028, IRA-driven Medicare drug pricing pressure, aggressive PBM consolidation driving harder formulary management, or BYSANTI launching at a price point that invites payor pushback.
+
+---
+
+## What Consensus May Be Missing
+
+**Bearish insight that bulls are underweighting:** The market is treating BYSANTI's approval and 2044 patent expiry as a straightforward positive catalyst. But the Claritin-to-Clarinex and Prilosec-to-Nexium precedents show that active metabolite evergreening strategies face severe payor pushback. The psychiatric market provides some protection due to higher clinical switching costs, but the fundamental economic dynamic is the same: payors will not willingly pay branded prices for bioequivalent generics. The 18-year patent life creates the *legal right* to sell BYSANTI, but not the *commercial certainty* that anyone will buy it at branded pricing. Patents protect against generic milsaperidone -- they do not protect against generic iloperidone being used instead.
+
+**Bullish insight that bears may be underweighting:** The one genuine strategic option that could break the evergreening ceiling is the MDD adjunct indication. If the Phase 3 trial succeeds (results expected end of 2026), BYSANTI would have an indication that generic iloperidone does NOT have. This would create a clinical reason for payors to differentiate BYSANTI from generic iloperidone, potentially transforming the drug from a me-too repackaging to a differentiated asset. The MDD indication alone will not create a moat, but it would substantially improve the commercial positioning. The LAI formulation optionality is a second potential differentiator but is much further from realization.
+
+**The second-order competitive insight:** Vanda's real strategic play is not BYSANTI as an oral tablet competing with generic iloperidone. It is BYSANTI as a platform for label extensions (MDD, potentially others) and formulation innovation (LAI) that generic iloperidone cannot legally match because those new indications and formulations would be protected under BYSANTI's separate patent estate. The oral tablet for schizophrenia and bipolar I is the beachhead; the value creation depends on whether Vanda can build on top of it. If the MDD trial fails and the LAI never materializes, BYSANTI oral for schizophrenia/bipolar I is a Clarinex-like outcome. If both succeed, it is something materially better.
+
+---
+
+## Moat & Durability Classification
+
+**Moat Strength: Weak**
+
+Justification: BYSANTI has legal patent protection through 2044, which prevents generic milsaperidone specifically. But the competitive moat against therapeutic substitution (generic iloperidone, generic aripiprazole, generic quetiapine, branded Caplyta, branded Cobenfy) is minimal. The drug's pharmacology is identical to a 17-year-old molecule that never achieved significant market share. The business model depends on commercial execution and payor management, not structural competitive advantage. The switching costs in psychiatry are real but do not create the kind of entrenched positioning that prevents competitive erosion. Vanda's commercial scale (~300 reps) is dwarfed by competitors like J&J (Caplyta) and BMS (Cobenfy). There is no network effect, no cost advantage, and no brand-driven pricing power beyond the legal monopoly on the specific molecule.
+
+**Earnings Durability: Low**
+
+Justification: Current earnings are negative. The path to profitability depends on successful commercial launches of two new products (BYSANTI and NEREUS) while the company's legacy cash-flow generator (HETLIOZ) continues to erode and its growth product (Fanapt) faces generic entry in 2027-2028. The company is cash-flow negative with $263.8M in cash and management warning of higher burn in 2026. Even if BYSANTI launches successfully, its long-term revenue potential is constrained by the payor dynamics described above. Revenue visibility is low, competitive intensity is high, and the business has no demonstrated ability to generate sustained profits. The bull case requires multiple things to go right (BYSANTI commercial traction + payor acceptance + MDD trial success + managed cash burn); the bear case requires only one thing to go wrong (payor step therapy mandating generic iloperidone).
+
+---
+
+## Key Sources
+
+- [Vanda Pharmaceuticals FDA Approval of BYSANTI Press Release (Feb 20, 2026)](https://www.prnewswire.com/news-releases/vanda-pharmaceuticals-announces-fda-approval-of-bysanti-milsaperidone-for-the-treatment-of-bipolar-i-disorder-and-schizophrenia---a-new-chemical-entity-opening-new-horizons-in-psychiatric-innovation-302693941.html)
+- [Vanda Pharmaceuticals Q4/FY2025 Financial Results](https://www.prnewswire.com/news-releases/vanda-pharmaceuticals-reports-fourth-quarter-and-full-year-2025-financial-results-302685633.html)
+- [Vanda Pharmaceuticals FDA Approval of NEREUS Press Release (Dec 30, 2025)](https://www.prnewswire.com/news-releases/vanda-pharmaceuticals-announces-fda-approval-of-nereus-tradipitant-for-the-prevention-of-vomiting-induced-by-motion-a-historic-scientific-milestone-in-the-prevention-of-motion-sickness-302650965.html)
+- [Fanapt Bipolar I FDA Approval (April 2024)](https://www.prnewswire.com/news-releases/vanda-pharmaceuticals-fanapt-iloperidone-receives-us-fda-approval-for-the-acute-treatment-of-bipolar-i-disorder-302106405.html)
+- [Vanda-Taro Fanapt Patent Settlement](https://www.prnewswire.com/news-releases/vanda-pharmaceuticals-settles-fanapt-patent-litigation-with-taro-300349897.html)
+- [DrugPatentWatch: Fanapt Patent and Generic Timeline](https://www.drugpatentwatch.com/p/tradename/FANAPT)
+- [JMCP: Patterns of Care and Costs of Switching Oral Antipsychotics (2024)](https://www.jmcp.org/doi/10.18553/jmcp.2024.23274)
+- [JMCP: Reasons for Switching Oral Antipsychotics (2024)](https://www.jmcp.org/doi/10.18553/jmcp.2024.23319)
+- [Psychiatric Times: Switching Antipsychotics](https://www.psychiatrictimes.com/view/switching-antipsychotics-why-when-and-how)
+- [Psychiatric Times: FDA Approves Bysanti](https://www.psychiatrictimes.com/view/fda-approves-bysanti-for-treatment-of-bipolar-1-disorder-and-schizophrenia)
+- [Kavout: Has Vanda Found Its Game-Changer with Bysanti](https://www.kavout.com/market-lens/has-vanda-pharmaceuticals-finally-found-its-game-changer-with-bysanti)
+- [BioPharma Dive: Cobenfy Launch](https://www.biopharmadive.com/news/cobenfy-bristol-myers-sales-schizophrenia-drug-launch/739410/)
+- [CAPLYTA Market Adoption (DelveInsight)](https://www.globenewswire.com/news-release/2025/02/21/3030616/0/en/CAPLYTA-s-Strong-Market-Adoption-Propels-Its-Rise-as-a-Leading-Antipsychotic-Therapy-DelveInsight.html)
+- [PMC: Drug Patents -- The Evergreening Problem](https://pmc.ncbi.nlm.nih.gov/articles/PMC3680578/)
+- [DrugPatentWatch: Evergreening Strategy Guide](https://www.drugpatentwatch.com/blog/the-evergreening-gambit-a-strategic-guide-to-pharmaceutical-patent-lifecycle-management/)
+- [Jefferies Analyst Andrew Tsai commentary via Kavout](https://www.kavout.com/market-lens/has-vanda-pharmaceuticals-finally-found-its-game-changer-with-bysanti)
+- [Vanda Q4 2025 Earnings Call Highlights](https://www.dailypolitical.com/2026/02/13/vanda-pharmaceuticals-q4-earnings-call-highlights.html)

--- a/claude/VNDA/capital-allocation-analyst.md
+++ b/claude/VNDA/capital-allocation-analyst.md
@@ -1,0 +1,285 @@
+# Vanda Pharmaceuticals (VNDA) -- Management Quality & Capital Allocation Assessment
+
+**Date:** 2026-02-23
+**Stock Price:** ~$8.00 | **Market Cap:** ~$340M | **Shares Outstanding:** ~59.1M
+**Analyst Framework:** Incentive-driven, behavior-based assessment of capital allocation competence
+
+---
+
+## Executive Summary
+
+Mihael Polymeropoulos has run Vanda Pharmaceuticals for over two decades. The observable record is a founder-CEO who has preserved optionality at shareholders' expense: rejecting premium takeover offers while the stock destroyed 70%+ of its value from peak, paying himself $40M+ over a decade while cumulative shareholder returns were deeply negative, adopting poison pills and bylaw amendments to entrench his control, and spending down a $467M cash pile to $264M without generating a single year of meaningful free cash flow since 2021. He now faces the most consequential capital allocation decision in the company's history -- commercially launching three new products simultaneously -- and has already filed a $200M shelf registration signaling likely dilutive financing ahead. The question is not whether Polymeropoulos is incentivized to grow the company. He clearly is. The question is whether he is incentivized to grow it *profitably* and *for shareholders*. The evidence says no.
+
+---
+
+## 1. Management Overview (Factual)
+
+**Mihael H. Polymeropoulos, M.D.**
+- Founder, President, CEO, and Chairman of the Board
+- Has served as CEO since inception (2003); Chairman since June 2021
+- Direct ownership: ~2.86M shares (~4.8% of shares outstanding), including unvested RSUs
+- Open-market purchases in 2025: 80,000 shares at ~$4.20-$5.02/share (~$324,000 total)
+- No reported insider sales in the past year
+
+**Kevin Moran** -- SVP, CFO, Treasurer
+**Gunther Birznieks** -- SVP
+**Timothy Williams** -- SVP
+**Joakim Wijkstrom** -- SVP, CMO
+
+**Board:** Six directors, five independent per Nasdaq standards. CEO is the only non-independent director. CEO is also Chairman -- a dual role that concentrates power.
+
+**ISS Governance QualityScore:** 5 overall (decile, where 10 = highest risk). Board: 6; Compensation: 6. Above-average governance risk.
+
+---
+
+## 2. Incentive Structure & Alignment
+
+### Compensation Mix
+
+| Year | CEO Total Comp | Approx. Cash % | Approx. Equity % |
+|------|---------------|----------------|-------------------|
+| 2021 | $6.19M | ~22% | ~77% |
+| 2022 | $4.27M | ~35% | ~64% |
+| 2024 | $3.90M | Est. ~35-40% | Est. ~60-65% |
+
+**Activist Data Point (Shareholder Capital LLC, April 2024):** Over the ten reported years from 2013-2022, Polymeropoulos received $40M+ in total compensation. His compensation is "significantly more cash-weighted compared to peer CEOs" -- 35% cash vs. 16-18% cash for peers (per 2022 proxy). This is a meaningful deviation. A founder who extracts more cash relative to peers is signaling a preference for guaranteed payout over equity upside.
+
+**2025 Base Salary:** $965,655 with an 80% target bonus. This means cash compensation alone (salary + target bonus) = ~$1.74M/year before any equity grants.
+
+**2024 Bonus:** $947,928, paid at 127% of target. The bonus was driven by 107% quantitative achievement and 116% qualitative achievement. In a year where Vanda posted a $18.9M net loss and the stock traded below $5, a bonus at 127% of target raises obvious questions about metric calibration.
+
+### Performance Metrics
+
+From 2024 onward, equity awards are solely RSUs with four-year vesting (no performance conditions disclosed beyond time vesting). This is pure retention compensation -- it rewards staying, not performing. There are no disclosed ROIC, ROCE, or capital efficiency hurdles. There are no disclosed TSR-based performance triggers.
+
+**What behavior does this compensation encourage?**
+It encourages the CEO to remain in his seat and grow the top line. There is no observable penalty for capital misallocation, no incentive for return on invested capital, and no mechanism linking compensation to shareholder returns. The CEO benefits from company survival regardless of stock performance. This is a structure that rewards empire building.
+
+**Who benefits most if the stock underperforms?**
+The CEO. His cash compensation ($1.7M+ annually) is guaranteed regardless of stock price. His RSUs vest on time alone. His entrenchment provisions (poison pill, bylaw amendments) make removal nearly impossible. An underperforming stock actually helps him -- it reduces the acquisition threat that might cost him his position.
+
+### Say-on-Pay
+
+79% approval in 2024. This is weak support. Anything below 80% indicates meaningful shareholder dissatisfaction. The Compensation Committee has acknowledged monitoring evolving practices but has not made material structural changes.
+
+---
+
+## 3. Stock-Based Compensation Discipline
+
+### SBC as a Real Cost
+
+| Year | SBC Expense | Revenue | SBC/Revenue | Free Cash Flow | SBC/FCF |
+|------|------------|---------|-------------|----------------|---------|
+| 2021 | $15.4M | $268.7M | 5.7% | $63.7M | 24% |
+| 2022 | $16.3M | $254.4M | 6.4% | $31.3M | 52% |
+| 2023 | $14.0M | $192.6M | 7.3% | -$88.3M | N/A (neg FCF) |
+| 2024 | $12.4M | $198.8M | 6.2% | -$20.5M | N/A (neg FCF) |
+| 2025 | $9.5M | $216.1M | 4.4% | -$110.4M | N/A (neg FCF) |
+
+SBC as a percentage of revenue has actually declined, which is modestly positive. The absolute dollar decline from $16.3M (2022) to $9.5M (2025) reflects the shift from options to RSUs and likely fewer total grants at lower stock prices. However, SBC as a percentage of revenue is misleading when the company is deeply FCF-negative. The real question is: what is the dilution impact?
+
+### Share Count Trajectory
+
+| Year-End | Shares Outstanding | YoY Change |
+|----------|--------------------|------------|
+| 2021 | 55.91M | -- |
+| 2022 | 56.79M | +1.6% |
+| 2023 | 57.54M | +1.3% |
+| 2024 | 58.32M | +1.4% |
+| 2025 | 59.10M | +1.3% |
+
+Over four years: 55.91M to 59.10M = +3.19M shares = +5.7% dilution. This is ~1.4% annual dilution from SBC alone.
+
+**No buybacks to offset.** The cash flow statement shows $0.92M in repurchases in FY2025 -- a rounding error. Common stock issuance was $0.73M in 2022 and $3.55M in 2021; zero in 2023-2025. Vanda has never run a meaningful buyback program despite holding $400M+ in cash and marketable securities during years when the stock traded at negative enterprise value.
+
+**Dilution verdict:** Moderate in absolute terms (~1.4%/yr), but there is zero offset via buybacks. Every share issued is pure dilution. Management treats SBC as free money.
+
+### The RSU Grants Tell a Story
+
+- Feb 2025: CEO awarded 450,000 RSUs + top four SVPs received 125,000 each = 950,000 shares to five people = 1.6% of shares outstanding
+- Feb 2026: CEO awarded 525,000 RSUs alone = 0.9% of shares outstanding to one person
+
+The CEO's 2026 RSU grant (525,000 shares) is larger than his 2025 grant (450,000 shares) despite the stock price being higher. This is a founder who is escalating his take, not moderating it. At $8/share, the 2026 CEO RSU grant alone is worth $4.2M.
+
+---
+
+## 4. Capital Allocation Track Record
+
+### a) Reinvestment
+
+**Commercial Infrastructure Build (2024-2025):**
+SG&A expenses surged from $146.4M (2024) to $238.0M (2025), a 63% increase. The sales force nearly doubled to ~300 reps with ~50 specialty reps. R&D spending increased from $74.4M to $109.3M.
+
+This is the most capital-intensive period in Vanda's history. The company is simultaneously building out commercial capabilities for Fanapt (bipolar I expansion), PONVORY (MS), and preparing for NEREUS and BYSANTI launches.
+
+**The problem:** Incremental returns are currently negative. Revenue grew 9% ($17.3M) while operating expenses grew 53% ($127.9M). The company is spending $7.38 for every $1 of incremental revenue. This needs to improve dramatically or cash will be exhausted within 2-3 years.
+
+**Historical commercial track record -- Fanapt:**
+Fanapt was approved in 2009. Vanda licensed U.S./Canadian rights to Novartis in October 2009 for $200M upfront + potential $265M in milestones + royalties. This was a reasonable decision for a small company without commercial infrastructure. However, Novartis could not make Fanapt commercially successful (peak expectations of $300M/year; actual peak ~$95M). The license agreement devolved into arbitration. In December 2014, Vanda reacquired rights via settlement: Novartis transferred all U.S./Canadian rights, made a $25M equity investment at $13.82/share, and granted a license to AQW051.
+
+The Novartis settlement was arguably Vanda's best capital allocation decision. Rather than paying cash for the rights, Vanda received $25M to take them back. But the subsequent commercial execution was underwhelming -- Fanapt reached $95M in peak sales in 2021, well below the drug's potential according to initial analyst estimates. The recent bipolar I expansion is driving growth (2025 sales up 24% to $117.3M), which represents the first real commercial execution in the drug's history.
+
+**HETLIOZ commercialization:**
+HETLIOZ was approved in 2014 for Non-24-Hour Sleep-Wake Disorder. It was a legitimate orphan drug commercial success, peaking at ~$134M in annual sales. However, the franchise is now in terminal decline due to generic competition: $100.2M (2023) to $76.7M (2024) to $71.4M (2025). Vanda failed to get label expansions (jet lag disorder denied, insomnia failed) and has no strategy to arrest the decline. HETLIOZ will likely be a sub-$50M product within 2-3 years.
+
+**Verdict on reinvestment:** Mixed. The HETLIOZ orphan drug launch was competent. The Fanapt commercial track record under both Novartis and Vanda was subpar for a decade but has recently improved. The current SG&A spending surge is an all-or-nothing bet that needs to produce results within 12-18 months.
+
+### b) M&A
+
+**Ponvory Acquisition (December 2023):**
+Vanda paid $100M to Actelion/Janssen for U.S. and Canadian rights to PONVORY (ponesimod), an approved MS drug. This was an asset acquisition of an already-commercial product.
+
+Assessment:
+- Price paid: $100M for a product doing approximately ~$28M in annualized sales at the time of acquisition. That is ~3.6x trailing revenue for a specialty drug -- not unreasonable.
+- Result: PONVORY generated $27.8M in 2024 and $27.4M in 2025. Essentially flat. The acquisition has not shown organic growth under Vanda's ownership.
+- Strategic logic: MS is outside Vanda's core psychiatry/rare disease expertise. The rationale appears to be revenue diversification, not therapeutic synergy.
+- Timing: December 2023, when Vanda's stock was around $4-5 and the company had $388M in cash. Spending 26% of cash on a non-core asset when the company was already burning cash is questionable.
+
+**Imsidolimab License (February 2025):**
+Vanda paid AnaptysBio $10M upfront + $5M for drug supply + up to $35M in milestones + 10% royalty for global rights to imsidolimab (IL-36R antagonist for generalized pustular psoriasis, GPP).
+
+Assessment:
+- This is a well-structured, low-risk deal. $15M upfront for a Phase 3-ready rare disease asset with completed registration trials is inexpensive.
+- GPP is a true orphan indication where small commercial teams can compete.
+- BLA already submitted in Q4 2025.
+- If approved, this is a high-margin, low-cost-to-commercialize asset that fits Vanda's rare disease capabilities.
+
+**M&A verdict:** The Ponvory acquisition was mediocre -- an expensive diversification into a non-core area with no growth to show for it. The imsidolimab deal is well-structured and potentially value-creating. The pattern suggests management is getting better at deal-making, but the sample size is small.
+
+### c) Buybacks & Issuance
+
+**Buybacks:** Effectively zero. $0.92M in FY2025 repurchases is a rounding error. No meaningful buyback program has ever been executed despite the stock trading at negative enterprise value for extended periods in 2023-2024.
+
+**This is a critical failure.** When a company has $375-$467M in cash and its market cap is below its net cash balance, every dollar NOT spent on buybacks at those prices is value destruction. A rational capital allocator would have been aggressively repurchasing shares at $4-5 when the company had $375M in cash. Instead, Polymeropoulos rejected $7.25-$8.00 takeover offers and did nothing with the cash.
+
+**Equity Issuance:** On February 12, 2026, Vanda filed a $200M mixed securities shelf registration. The shelf covers common stock, preferred stock, debt securities, warrants, and units. The filing came one day after reporting FY2025 results showing cash declining $111M year-over-year and management guiding for accelerated cash burn in 2026.
+
+**This is the clearest signal of future dilution.** A $200M shelf at a $340M market cap means management is prepared to dilute existing shareholders by up to 59% if they draw down the full amount. Given the cash burn trajectory (~$110M in 2025, guided higher for 2026), it is likely that Vanda will need to raise capital within 12-18 months. At $8/share, a $100M raise would add ~12.5M shares, diluting existing holders by ~21%.
+
+**Net share count trajectory:**
+- 2021: 55.9M shares, $433M net cash
+- 2025: 59.1M shares, $251M net cash
+- Result: +5.7% more shares, $182M less cash
+
+Shareholders received: zero dividends, zero buybacks, 5.7% dilution, and a declining cash balance.
+
+### d) Debt Usage
+
+Vanda carries minimal debt (~$12.6M, likely operating leases). This is appropriate for a company with volatile cash flows and no consistent profitability. Debt discipline is a non-issue.
+
+However, the $200M shelf registration could include debt securities, which would be a new risk factor if Vanda levers up to fund commercial launches.
+
+---
+
+## 5. Learning vs. Repetition
+
+### Evidence of Learning
+
+1. **Fanapt Commercial Execution (2024-2025):** After a decade of underwhelming Fanapt sales, the bipolar I expansion and new commercial investment are finally producing growth (24% increase in 2025, new-to-brand prescriptions up 149%). This is the strongest evidence that management is learning from past commercial underperformance.
+
+2. **Imsidolimab Deal Structure:** A $15M upfront for a Phase 3-ready orphan asset is a disciplined deal, far superior to paying $100M for the stagnant Ponvory franchise.
+
+3. **SBC Declining as % of Revenue:** From 7.3% (2023) to 4.4% (2025), directionally positive.
+
+### Evidence of Repetition
+
+1. **Rejecting Premium Offers While Destroying Value:** Rejected $7.25-$8.00 offers (Future Pak, Cycle Pharmaceuticals) in 2024 at 63-92% premiums. The stock subsequently traded at $3.81. Management has consistently prioritized its own survival over shareholder value realization. The fact that the stock only recently recovered to $8 -- the price Cycle offered 16 months ago -- is evidence that rejecting the bid was not obviously correct. Shareholders who held through that period received nothing.
+
+2. **Entrenchment Behavior:** Adopted a poison pill in April 2024. Amended bylaws in October 2024 to restrict shareholder meeting rights, director nominations, and board actions -- two business days before rejecting Cycle's second bid. This is textbook entrenchment. It has been repeated across multiple years and multiple suitors.
+
+3. **No Capital Returns Despite Excess Cash:** Over the entire 2021-2025 period, with cash ranging from $264M to $467M and the stock trading well below net cash for extended periods, management returned nothing to shareholders. This is not an isolated decision; it is a pattern. Management views shareholder cash as its own.
+
+4. **CEO Compensation Escalation During Value Destruction:** $40M+ in compensation over 10 years while the stock went from ~$20 to ~$5. The 2026 RSU grant (525,000 shares) is larger than the 2025 grant (450,000 shares). Compensation is escalating into the teeth of shareholder losses.
+
+**Verdict:** There is recent evidence of improved commercial execution (Fanapt) and deal-making (imsidolimab). But the governance and capital return failures are deeply entrenched and show no sign of improvement. The learning is operational; the repetition is behavioral.
+
+---
+
+## 6. Forward-Looking Capital Allocation Risk
+
+### Cash Runway Analysis
+
+| | FY2025 Actual | FY2026 Estimated |
+|---|---|---|
+| Revenue | $216M | $230-260M (guidance, ex-new products) |
+| Operating Expenses | $367M | Est. $400-450M (mgmt guided higher) |
+| Operating Cash Burn | ~$109M | Est. $120-160M+ |
+| Year-End Cash | $264M | Est. $100-150M |
+
+Management explicitly stated 2026 cash burn will exceed 2025 levels. With three product launches (NEREUS, BYSANTI, imsidolimab) and a salesforce buildout, expenses will continue rising before revenue catches up.
+
+**Critical funding question:** At the current burn rate, Vanda has approximately 18-24 months of runway before cash reaches uncomfortable levels (~$100M). The $200M shelf registration confirms management's awareness of this constraint.
+
+### What Management Is Likely to Do Next
+
+1. **Raise equity capital in 2026.** The $200M shelf registration is a near-certainty signal. Management will likely raise $75-150M through an equity offering, possibly timed around BYSANTI commercial traction data or analyst day. Existing shareholders should assume 15-25% dilution.
+
+2. **Continue scaling SG&A aggressively.** The sales force will likely grow to 400-500+ reps to cover psychiatry (BYSANTI/Fanapt), MS (PONVORY), and consumer/primary care (NEREUS). Operating expenses could reach $400-450M in 2026.
+
+3. **No capital returns.** Dividends and buybacks are not on the table. Every dollar of cash will be deployed into commercial infrastructure and pipeline advancement.
+
+4. **Possible additional M&A.** Polymeropoulos has demonstrated a pattern of adding products (Ponvory, imsidolimab). If he perceives a bargain, he may acquire additional assets, further draining cash.
+
+### Where Capital Is Most Likely to Be Misallocated
+
+1. **NEREUS commercial launch.** Motion sickness is a consumer/OTC-adjacent market. Vanda has no experience in DTC pharmaceutical marketing at scale. The risk of overspending on consumer marketing for NEREUS without adequate ROI is high.
+
+2. **Over-investing in PONVORY.** MS is a competitive, dominated-by-large-pharma market. PONVORY has shown zero growth under Vanda's ownership. Continued investment here has questionable ROI.
+
+3. **Equity dilution at the wrong price.** If Vanda raises equity at $6-8/share to fund launches that may not generate returns for 2-3 years, existing shareholders bear the dilution while management bears none of the downside.
+
+---
+
+## The One Thing That Determines Value Creation
+
+**Whether Fanapt + BYSANTI can reach $300M+ in combined psychiatry revenue by 2028 without requiring a second equity raise.**
+
+This is the dominant factor because:
+
+- BYSANTI (milsaperidone) is essentially a prodrug of iloperidone (Fanapt) with NCE status and patent protection through 2044. It leverages Fanapt's existing clinical data and physician familiarity. If Vanda's existing psychiatry salesforce can cross-sell BYSANTI effectively, the incremental cost of launching is far lower than a de novo product.
+- Fanapt is already demonstrating commercial acceleration ($117M in 2025, up 24%). If BYSANTI adds incremental revenue on the same commercial infrastructure, Vanda could reach cash flow breakeven without dilutive financing.
+- If the psychiatry franchise fails to scale, Vanda will burn through its remaining $264M in cash within 2-3 years, be forced to raise equity at distressed prices, and shareholders will suffer catastrophic dilution.
+
+Everything else -- NEREUS, PONVORY, imsidolimab -- is optionality, not the core investment thesis. The psychiatry franchise is what determines whether this management team creates or destroys value.
+
+---
+
+## What Consensus May Be Missing
+
+**Consensus appears to be pricing in the FDA approvals but underestimating the governance risk premium this management team deserves.**
+
+The specific non-consensus insight: Polymeropoulos rejected an $8/share all-cash offer from Cycle Pharmaceuticals in October 2024 when the stock was at $4.44. The stock has only now returned to ~$8 -- 16 months later, after two FDA approvals and significant cash burn. Shareholders who held through that period received exactly the same price that was available in cash, with certainty, 16 months ago -- minus $111M in corporate cash that was spent.
+
+Put differently: Cycle offered to buy the company at $8 when there was $375M in cash ($6.43/share in cash alone). Today, the stock is $8 with $264M in cash ($4.47/share). The "intrinsic value" the board claimed to be protecting has actually declined by $1.96/share in cash alone, even as the stock price recovered to the offer level.
+
+**This pattern -- rejecting premium bids, burning cash, claiming intrinsic value while destroying it -- is the single most important risk factor for VNDA shareholders.** It suggests that Polymeropoulos values control over liquidity and will continue to do so. If the commercial launches underperform, there is no exit valve. He will not sell the company at a reasonable premium, and he will not return capital. Shareholders are locked into his execution with limited governance recourse.
+
+---
+
+## Final Classification
+
+| Dimension | Rating | Detail |
+|-----------|--------|--------|
+| **Incentive Alignment** | **Weak** | Cash-heavy comp vs. peers, no performance-based equity hurdles, escalating RSU grants during underperformance, dual Chairman/CEO role with entrenchment provisions. 4.8% ownership is meaningful but insufficient to overcome structural misalignment. |
+| **Capital Allocation Discipline** | **Low** | Zero capital returns over five years despite massive excess cash. Rejected premium takeover offers. $100M spent on non-core Ponvory with no growth. $200M shelf filed signaling dilutive raise. Cash declining $182M over four years while share count increased 5.7%. |
+| **Dilution Risk** | **High** | $200M shelf registration at $340M market cap = up to 59% dilution capacity. Cash burn of $110M+ annually. Management has guided for accelerating burn in 2026. No history of buybacks. Near-certain equity raise within 12-18 months. |
+| **Primary Risk** | **Management raises dilutive equity at depressed prices to fund commercial launches that underperform, while rejecting any acquisition interest that would crystallize value for shareholders. Polymeropoulos optimizes for control and tenure, not shareholder returns.** |
+
+---
+
+## Key Sources
+
+- Vanda Pharmaceuticals FY2025 Earnings Release (February 11, 2026): [PR Newswire](https://www.prnewswire.com/news-releases/vanda-pharmaceuticals-reports-fourth-quarter-and-full-year-2025-financial-results-302685633.html)
+- BYSANTI FDA Approval Announcement (February 20, 2026): [PR Newswire](https://www.prnewswire.com/news-releases/vanda-pharmaceuticals-announces-fda-approval-of-bysanti-milsaperidone-for-the-treatment-of-bipolar-i-disorder-and-schizophrenia---a-new-chemical-entity-opening-new-horizons-in-psychiatric-innovation-302693941.html)
+- NEREUS FDA Approval (December 30, 2025): [PR Newswire](https://www.prnewswire.com/news-releases/vanda-pharmaceuticals-announces-fda-approval-of-nereus-tradipitant-for-the-prevention-of-vomiting-induced-by-motion-a-historic-scientific-milestone-in-the-prevention-of-motion-sickness-302650965.html)
+- $200M Shelf Registration (February 12, 2026): [Stock Titan](https://www.stocktitan.net/sec-filings/VNDA/s-3-vanda-pharmaceuticals-inc-shelf-registration-statement-de1302cc3960.html)
+- Cycle Pharmaceuticals $8/share Bid Rejection (October 2024): [Fierce Pharma](https://www.fiercepharma.com/pharma/vanda-swats-down-another-buyout-bid-cycle)
+- Future Pak Takeover Rejection & Poison Pill (April 2024): [PR Newswire](https://www.prnewswire.com/news-releases/vanda-pharmaceuticals-confirms-rejection-of-unsolicited-takeover-proposals-from-future-pak-302119534.html)
+- Shareholder Capital LLC Activist Letter (April 2024): [GlobeNewsWire](https://ml.globenewswire.com/Resource/Download/9fb456e3-2227-470c-9737-fa3d0566f018)
+- Ponvory Acquisition ($100M, December 2023): [BioSpace](https://www.biospace.com/vanda-buys-us-canadian-rights-to-j-and-j-s-ms-drug-ponvory-in-100m-deal)
+- Imsidolimab License Agreement (February 2025): [PR Newswire](https://www.prnewswire.com/news-releases/vanda-pharmaceuticals-and-anaptys-announce-exclusive-global-license-agreement-for-vanda-to-develop-and-commercialize-imsidolimab-an-il-36r-antagonist-302366027.html)
+- Fanapt Reacquisition from Novartis (December 2014): [Fierce Biotech](https://www.fiercebiotech.com/biotech/vanda-to-regain-us-and-canadian-rights-to-fanapt%C2%AE)
+- CEO Compensation & Insider Buying: [Investing.com](https://www.investing.com/news/insider-trading-news/vanda-pharmaceuticals-ceo-mihael-polymeropoulos-purchases-47650-in-stock-93CH-3894262); [Stock Titan Form 4](https://www.stocktitan.net/sec-filings/VNDA/form-4-vanda-pharmaceuticals-inc-insider-trading-activity-792bae7e113e.html)
+- CEO Compensation History: [AFL-CIO PayWatch](https://aflcio.org/paywatch/VNDA); [Salary.com](https://www1.salary.com/VANDA-PHARMACEUTICALS-INC-Executive-Salaries.html)
+- Financial Statements (Income, Balance Sheet, Cash Flow): [Stock Analysis](https://stockanalysis.com/stocks/vnda/financials/)
+- Fanapt Bipolar I Approval (April 2024): [PR Newswire](https://www.prnewswire.com/news-releases/vanda-pharmaceuticals-fanapt-iloperidone-receives-us-fda-approval-for-the-acute-treatment-of-bipolar-i-disorder-302106405.html)

--- a/claude/VNDA/industry-structure-cycle-analyst.md
+++ b/claude/VNDA/industry-structure-cycle-analyst.md
@@ -1,0 +1,353 @@
+# Industry Structure & Cycle Analysis: Antipsychotic / Psychiatry Drug Market
+
+**Date:** 2026-02-23
+**Relevant Company Context:** VNDA (Vanda Pharmaceuticals) -- used solely to identify the relevant industry; all analysis is industry-level
+**Industry Scope:** US branded antipsychotic drugs for schizophrenia and bipolar I disorder
+
+---
+
+## The One Industry Factor That Matters
+
+**The single most important variable for this industry's economics is formulary access and payor willingness to cover branded antipsychotics over cheap generics.**
+
+The antipsychotic market is structurally bifurcated: generics dominate prescription volume (>70% of scripts), but branded drugs dominate spending (~91% of total antipsychotic expenditure per Medicaid data, 2021). Every new branded entrant must fight for formulary position against a wall of $5-10/day generic alternatives (olanzapine, quetiapine, risperidone, aripiprazole). The industry's economics are not primarily determined by clinical differentiation -- they are determined by whether payors will grant formulary access without onerous step-therapy or prior authorization requirements. A drug that is clinically superior but formulary-restricted will lose to a clinically adequate generic that is freely prescribed.
+
+**What would cause this to inflect:** (1) Regulatory changes to Medicaid "open access" policies for antipsychotics -- several states are tightening formulary restrictions, which disadvantages branded entrants. (2) A definitive outcomes study demonstrating that a new branded agent reduces hospitalizations enough to justify its cost premium -- this is the holy grail that no recent branded antipsychotic has delivered at scale. (3) The IRA's negotiation provisions eventually reaching smaller branded psychiatry drugs, compressing net pricing further.
+
+**How to monitor it:** Track commercial and Medicaid formulary wins/losses for each branded entrant. Watch prior authorization rejection and prescription abandonment rates (currently ~37% of initially rejected antipsychotic scripts are abandoned entirely). Monitor gross-to-net spreads for branded antipsychotics -- Fanapt currently runs ~50% gross-to-net, indicating heavy rebating.
+
+---
+
+## What Consensus May Be Missing
+
+**Consensus view:** The antipsychotic market is in a "psychiatry renaissance" driven by novel mechanisms (Cobenfy/KarXT, Caplyta expansion), creating a rising tide that lifts all branded boats. New entrants can carve out meaningful share in an $8B+ combined US market.
+
+**What consensus may be wrong about:** The "psychiatry renaissance" narrative is real at the level of large-cap pharma M&A and novel mechanism validation, but it is **almost entirely irrelevant for a small-cap launching a derivative of an existing molecule into a crowded branded field.** The market is not experiencing a general supply shortage of antipsychotics -- it is experiencing selective excitement about genuinely novel mechanisms (muscarinic agonism via Cobenfy, Caplyta's unique receptor profile). BYSANTI (milsaperidone), as the active metabolite of iloperidone (Fanapt), does not represent a novel mechanism. It is a lifecycle management strategy -- a new chemical entity built on bioequivalence to an existing drug with modest market share.
+
+The variant insight is this: **the M&A frenzy in psychiatry is bidding up assets with novel mechanisms and large TAMs, but it is not bidding up reformulated or metabolite-derived drugs from existing antipsychotics.** The J&J/Intra-Cellular deal ($14.6B) and BMS/Karuna deal ($14B) were premised on genuinely differentiated pharmacology. The relevant comparison set for BYSANTI is not Caplyta or Cobenfy -- it is Lybalvi (olanzapine + samidorphan), which is also a lifecycle management play on an existing molecule. Lybalvi is growing ($350M 2025 guidance) but it took years and massive Alkermes commercial infrastructure to get there, and it remains a small player in the overall market.
+
+**This is bearish for industry-level economics as they apply to derivative branded antipsychotics.** The psychiatry renaissance is selectively rewarding novelty, not just brand status.
+
+---
+
+## Industry Structure
+
+### Market Size and Segmentation
+
+The US antipsychotic drug market is approximately $3.3 billion in 2025 (per Fact.MR), growing at ~6% CAGR. The broader combined US market for schizophrenia and bipolar I disorder treatments is $8B+, including mood stabilizers, anticonvulsants, and long-acting injectables. The global bipolar disorder therapeutics market is approximately $5.0-5.5 billion (Mordor Intelligence, SkyQuest).
+
+Key segmentation:
+- **Schizophrenia:** ~41% of antipsychotic demand. ~2.8 million US adults affected. High chronicity, high switching rates (64-82% discontinuation in CATIE), high unmet need.
+- **Bipolar I disorder:** ~62% of bipolar disorder market. ~10 million US patients affected. Bipolar I dominates treatment intensity.
+- **Second-generation (atypical) antipsychotics:** 63% revenue share of antipsychotic market (2024). This is the class relevant to BYSANTI.
+
+### Growth Characteristics
+
+The market is growing at 5-8% CAGR depending on the source and forecast window. However, growth is **unevenly distributed:**
+
+| Segment | Growth Driver | Rate |
+|---------|--------------|------|
+| Novel branded oral (Caplyta, Cobenfy) | New mechanism adoption | High (30-40% YoY for Caplyta) |
+| Long-acting injectables (LAIs) | Adherence improvement | High (targeting >30% share by 2026) |
+| Legacy branded (Lybalvi, Vraylar) | Lifecycle/reformulation | Moderate (15-30% YoY) |
+| Generics (volume) | Price erosion, formulary steering | Low-negative on revenue |
+
+This is **not a uniformly growing market.** Revenue growth is concentrated in a handful of branded drugs with differentiated profiles or novel mechanisms. The generic segment continues to see volume growth but revenue decline (-52% in generic spending 2016-2021 per Medicaid data).
+
+### Profitability Drivers
+
+What fundamentally drives profitability in branded antipsychotics:
+
+1. **Formulary access:** The gatekeeper. Without commercial and Medicaid formulary placement, volume cannot materialize regardless of clinical merit. Prior authorization requirements cause ~37% prescription abandonment.
+2. **Gross-to-net realization:** Branded antipsychotics operate with gross-to-net spreads of 40-55%, meaning heavy rebating to payors. New chemical entities can initially achieve better gross-to-net (~25-30%) before Medicaid rebate escalation kicks in.
+3. **Prescriber inertia/switching costs:** Psychiatrists are conservative prescribers who rely on 2-3 preferred agents. Switching stable patients risks destabilization -- the natural "moat" protecting incumbents, but also the barrier to new entrants.
+4. **Sales force reach and frequency:** The atypical antipsychotic class is promotionally sensitive. Detailing to psychiatrists directly correlates with prescription volume. This requires substantial SG&A investment ($80-100M+ annually per McKinsey).
+5. **Differentiation on side effects:** Weight gain, metabolic syndrome, extrapyramidal symptoms, and sedation are the primary switching triggers. Drugs that demonstrate superior tolerability profiles on these dimensions gain share over time.
+
+---
+
+## Competitive Dynamics
+
+### Current Competitive Map (Branded Antipsychotics, 2025-2026)
+
+| Drug | Company | Mechanism | 2025 Revenue (est.) | Differentiation |
+|------|---------|-----------|---------------------|-----------------|
+| **Caplyta** (lumateperone) | J&J (acq. Intra-Cellular) | 5-HT2A/D2/D1 modulator | $600-800M | Low metabolic SE, bipolar + schizophrenia + MDD. Broadest label. |
+| **Cobenfy** (KarXT) | Bristol Myers Squibb | M1/M4 muscarinic agonist | ~$120-150M (launch year) | First non-dopaminergic mechanism in 70 years. No EPS, low weight gain. Schizophrenia only (for now). |
+| **Lybalvi** (olanzapine/samidorphan) | Alkermes | D2/5-HT2A + opioid antagonist | $340-350M | Olanzapine efficacy with mitigated weight gain. Schizophrenia + bipolar I. |
+| **Vraylar** (cariprazine) | AbbVie | D3/D2 partial agonist | ~$2.5B+ (multi-indication) | Bipolar mania, bipolar depression, schizophrenia. Patent protected to 2029. |
+| **Fanapt** (iloperidone) | Vanda | D2/5-HT2A antagonist | ~$117M | Niche. Low EPS. Requires titration. |
+| **Rexulti** (brexpiprazole) | Otsuka/Lundbeck | D2/5-HT1A partial agonist | ~$1.5B+ | Schizophrenia + MDD adjunct + Alzheimer's agitation. |
+| **BYSANTI** (milsaperidone) | Vanda | D2/5-HT2A/alpha-1 antagonist | Pre-launch | NCE status, bioequivalent to iloperidone. Patent to 2044. Bipolar I + schizophrenia. |
+
+### Structural Competitive Assessment
+
+The competitive landscape is **consolidating at the top and fragmenting at the bottom:**
+
+- **Top tier (>$1B revenue):** Vraylar, Rexulti, Caplyta (trending). These are backed by AbbVie, Otsuka/Lundbeck, and J&J respectively -- companies with massive psychiatry sales forces (1,000+ reps) and deep formulary relationships.
+- **Mid tier ($200M-$1B):** Lybalvi, Cobenfy (early launch). Growing but still fighting for formulary position.
+- **Bottom tier (<$200M):** Fanapt, and prospectively BYSANTI. Small-company infrastructure, limited formulary leverage, niche prescriber adoption.
+
+The critical dynamic: **Big pharma is consolidating control of the branded antipsychotic market.** J&J acquired Caplyta for $14.6B. BMS acquired Cobenfy for $14B. AbbVie controls Vraylar. These companies can afford to out-invest smaller players on formulary negotiations, sales force coverage, and DTC marketing by orders of magnitude.
+
+### Pricing Power
+
+Industry-level pricing power for branded antipsychotics is **moderate and declining:**
+
+- New branded oral antipsychotics are priced at ~$20,000-25,000/year list (Cobenfy at $22,500/year).
+- Net pricing after rebates is substantially lower, typically 45-60% of list for mature brands.
+- Pricing power is constrained by: (a) cheap generic alternatives ($500-2,000/year), (b) payor step-therapy requirements, (c) increasing Medicaid formulary restrictions, (d) potential IRA negotiation expansion.
+- The industry cannot exercise meaningful pricing power because the product is not a scarce resource -- there are 12+ approved antipsychotics with generic versions available.
+
+---
+
+## Cyclicality Assessment
+
+### Is This Industry Cyclical?
+
+**Cyclicality: LOW**
+
+The antipsychotic drug market is **not meaningfully cyclical** in the traditional economic sense. Key reasons:
+
+1. **Demand is non-discretionary.** Schizophrenia and bipolar I disorder require ongoing treatment. Prescription volumes do not fluctuate with GDP, employment, or consumer confidence.
+2. **No capacity cycle.** Unlike commodity industries, there is no supply/demand balancing mechanism through capacity addition/removal. Supply is effectively unlimited once a drug is approved.
+3. **No inventory cycle.** Pharmaceutical distribution channels maintain stable inventory levels.
+4. **Pricing is administratively determined,** not market-determined. Formulary negotiations, rebate structures, and government pricing programs set effective prices.
+
+However, the industry **does have a product cycle** that mimics cyclicality:
+
+- **Patent/exclusivity cycle:** Branded drugs enjoy ~10-15 years of market exclusivity, followed by steep generic erosion (50-70% price decline). This creates a "cycle" of branded revenue that is entirely predictable and non-mean-reverting.
+- **Innovation cycle:** Waves of new mechanisms (muscarinic agonism being the current wave) create periods of excitement and investment, followed by maturation. The current period (2024-2026) represents a genuine innovation wave -- the first new mechanism in schizophrenia treatment in 70 years.
+- **M&A cycle:** Big pharma's patent cliff anxiety drives periodic acquisition surges. CNS/psychiatry overtook oncology in 2025 deal value ($30.7B per EY data). This cycle is currently at or near peak.
+
+### Current Cycle Position
+
+The relevant "cycle" for this industry is the **innovation/M&A cycle**, not a traditional economic cycle.
+
+**Current position: LATE CYCLE / PEAK in the psychiatry M&A and innovation enthusiasm cycle.**
+
+Evidence:
+- 2025 was a landmark year for pharma M&A: $228.4B in announced deals, up 73% from 2024.
+- CNS/psychiatry captured $30.7B in deal value in 2025, overtaking oncology for the first time.
+- Two major psychiatry acquisitions occurred in 2024-2025: BMS/Karuna ($14B) and J&J/Intra-Cellular ($14.6B).
+- Goldman Sachs predicts record-breaking pharma M&A in 2026, with "firepower" at $1.3 trillion across top 25 pharmas.
+- Multiple new branded antipsychotics are in launch or early commercialization simultaneously (Cobenfy, Caplyta MDD expansion, BYSANTI).
+
+This is important because **late-cycle M&A enthusiasm creates a favorable backdrop for small biotechs seeking acquisition or partnership, but an unfavorable competitive backdrop for independent commercial launches.** More branded competitors are entering the market simultaneously, fragmenting prescriber attention and formulary slots.
+
+---
+
+## Mid-Cycle Reference Point
+
+### What "Mid-Cycle" Means for Branded Antipsychotics
+
+Mid-cycle economics for a branded antipsychotic entrant look like:
+
+- **Revenue trajectory:** A new branded oral antipsychotic in a competitive indication typically reaches $200-400M in US annual revenue within 3-5 years of launch if successfully commercialized. This assumes adequate formulary access, differentiated positioning, and $80-100M+ annual SG&A investment.
+- **Peak revenue:** For drugs without genuinely novel mechanisms, peak US revenue of $500M-1B is achievable but rare. Only drugs with novel mechanisms or broad label expansion (Caplyta, Vraylar) have exceeded this range.
+- **Margins:** Branded antipsychotic gross margins are 70-85%, but net margins after SG&A, rebates, and cost of goods are typically 20-40% for established products. During the launch phase (years 1-3), products typically operate at a loss as SG&A ramps ahead of revenue.
+- **Gross-to-net:** Mid-cycle gross-to-net realization for a branded antipsychotic is 45-55%. New chemical entities may start at 25-30% but converge toward market norms within 3-5 years as Medicaid rebate obligations escalate.
+- **Market share:** A mid-cycle branded antipsychotic in a competitive segment holds 3-8% of total prescriptions in its approved indications. Caplyta, one of the most successful recent entrants, is estimated at 10-15% share in new schizophrenia scripts.
+
+### Historical Benchmarks: What Does "Normal" Look Like?
+
+Drawing from the past full cycle of branded antipsychotic launches (2009-2025):
+
+| Drug | Launch Year | Year 3 Revenue | Year 5 Revenue | Peak Revenue | Notes |
+|------|------------|----------------|----------------|--------------|-------|
+| Fanapt (iloperidone) | 2010 | ~$30M | ~$47M | ~$117M (2025) | Slow adoption, niche positioning. 15 years to reach $117M. |
+| Latuda (lurasidone) | 2010 | ~$250M | ~$800M | ~$2.0B | Blockbuster. Broad label. Strong Sunovion launch. |
+| Vraylar (cariprazine) | 2015 | ~$200M | ~$500M | ~$2.5B+ | Blockbuster. Multiple indications. AbbVie commercialization. |
+| Caplyta (lumateperone) | 2020 | ~$250M | ~$600-800M | TBD (est. $4-5B per J&J) | Fastest-growing. Novel profile. J&J acquired. |
+| Lybalvi (olanzapine/samidorphan) | 2021 | ~$190M | ~$340-350M | TBD | Moderate success. Lifecycle play on olanzapine. |
+| Cobenfy (KarXT) | 2024 | ~$120-150M (Y1) | TBD | Est. $2.5B by 2030 | Novel mechanism. Strong early launch. Adjunctive trial failed. |
+
+**The base rate for a new branded antipsychotic launched by a small company without a novel mechanism is $100-300M in peak annual US revenue.** Fanapt and Lybalvi (in its early years) represent the most relevant comparables for BYSANTI.
+
+---
+
+## Structural Headwinds and Tailwinds for a 2026 Antipsychotic Launch
+
+### Tailwinds
+
+1. **Psychiatry is the hottest therapeutic area for pharma M&A.** CNS deal value overtook oncology in 2025. A small-cap biotech with an approved psychiatry asset is, by definition, a potential acquisition target in a seller's market. Big pharma has $1.3 trillion in deployable capital (Goldman Sachs).
+
+2. **Growing market.** The US antipsychotic market is growing at 6% CAGR, driven by increasing diagnosis rates, expanded indications, and de-stigmatization of mental health treatment.
+
+3. **Unmet need remains substantial.** 64-82% of antipsychotic patients discontinue therapy within 18 months (CATIE data). Treatment-resistant populations are large. Any drug that can demonstrate improved adherence or tolerability has a clinical rationale.
+
+4. **NCE status provides temporary formulary advantage.** BYSANTI's new chemical entity designation provides 5 years of data exclusivity and resets Medicaid rebate obligations, potentially offering better gross-to-net economics than Fanapt (~25-30% vs. ~50%).
+
+5. **Existing commercial infrastructure.** The industry norm for first-time launchers is to build commercial infrastructure from scratch. Vanda already has ~300 psychiatry sales reps detailing to relevant prescribers -- this is a non-trivial advantage for any branded antipsychotic.
+
+### Headwinds
+
+1. **Competitive intensity is at a historical high.** The number of branded antipsychotics competing for formulary slots and prescriber mindshare is greater than at any point in the last decade. Caplyta (backed by J&J), Cobenfy (backed by BMS), Vraylar (backed by AbbVie), and Lybalvi (backed by Alkermes) all have larger sales forces and deeper formulary relationships.
+
+2. **BYSANTI lacks mechanistic novelty.** It is the active metabolite of iloperidone, bioequivalent to Fanapt. While NCE status provides regulatory and IP benefits, clinicians and payors will recognize this as a derivative, not a breakthrough. The psychiatry renaissance is rewarding novel mechanisms (muscarinic agonism, unique receptor profiles), not lifecycle management strategies.
+
+3. **Payor environment is hostile to branded antipsychotics without clear differentiation.** More than one-third of state Medicaid programs and Medicare Part D plans require prior authorization for at least one atypical antipsychotic. Step-therapy requiring trial of two generic antipsychotics first is standard. A derivative of an existing antipsychotic will face particularly tough formulary negotiations.
+
+4. **First-time commercial launch execution risk.** Per McKinsey data, first-time launchers reach only 63% of analyst expectations vs. 93% for experienced launchers. Only 28% of first-time launches exceed prelaunch forecasts. For most first-time launchers, company value peaks before launch and then declines. Vanda has Fanapt commercial experience, which partially mitigates this, but BYSANTI represents a different scale of launch ambition.
+
+5. **SG&A investment requirement creates cash burn.** First-time launchers typically invest $80-100M+ annually in SG&A. Vanda already guided that 2026 cash burn will exceed 2025. With total 2026 revenue guidance of $230-260M from existing products, the incremental BYSANTI launch cost will pressure the P&L for 2-3 years.
+
+6. **Generic iloperidone overhang.** One tentative ANDA approval exists for generic iloperidone. 63% of patent challenges are decided in favor of generic challengers. If generic iloperidone launches, it directly undermines Fanapt revenue (currently $117M and growing) and indirectly raises questions about BYSANTI's value proposition as a bioequivalent metabolite of a genericized drug.
+
+---
+
+## Supply Dynamics
+
+### Supply Elasticity
+
+Supply elasticity in the branded antipsychotic market is **effectively zero in the short term and unlimited in the long term.** This is the opposite of a commodity industry:
+
+- **Short-term:** New branded competitors take 8-12 years to develop from preclinical through FDA approval. No new entrant can respond to current market conditions -- the pipeline was determined years ago.
+- **Long-term:** If branded antipsychotic margins remain attractive, the pipeline will fill. Current pipeline is robust: Teva's LAI olanzapine, Cobenfy bipolar I expansion, Caplyta MDD expansion, multiple LAI formulations, and several early-stage novel mechanisms.
+- **Generic supply:** Effectively infinite. Once patents expire, generic manufacturers can produce at marginal cost. The relevant constraint is patent/exclusivity protection, not manufacturing capacity.
+
+### Capacity and Utilization
+
+These concepts do not apply in the traditional sense. The "capacity" equivalent is formulary slots and prescriber attention -- both are finite and increasingly contested. The relevant "utilization" metric is market share of total antipsychotic prescriptions, which for any single branded drug ranges from <1% to ~15%.
+
+---
+
+## Historical Mean Reversion Patterns
+
+In branded antipsychotics, mean reversion operates through two mechanisms:
+
+1. **Patent expiration / generic entry:** This is the dominant mean-reversion force. Branded drug revenue declines 50-80% within 2-3 years of generic entry. This is entirely predictable and not a "cycle" -- it is a structural certainty.
+
+2. **Competitive entry erosion:** When multiple branded competitors target the same indication, market share fragments and no individual drug reaches the peak revenues that a monopoly branded product would achieve. The current period exemplifies this -- 5+ branded antipsychotics all competing for marginal prescriptions creates a more fragmented revenue distribution than the 2005-2015 era when Abilify and Seroquel dominated.
+
+**There is no mean reversion in profitability** in the commodity sense. A successful branded antipsychotic will maintain high gross margins throughout its patent life. The risk is not margin compression -- it is failure to achieve adequate volume.
+
+---
+
+## Regulatory and Structural Constraints
+
+1. **Inflation Reduction Act (IRA):** Medicare drug price negotiation currently applies to high-spend drugs. Antipsychotics could eventually fall under negotiation, compressing net pricing for branded products. This is a medium-term (3-5 year) risk.
+
+2. **Medicaid open access erosion:** Several states are tightening antipsychotic formulary restrictions despite evidence that open access policies produce better patient outcomes and lower total costs. This trend disadvantages new branded entrants.
+
+3. **FDA accelerated pathways:** The 505(b)(2) pathway (which BYSANTI likely used, leveraging Fanapt data) lowers development costs but also lowers the perceived bar for differentiation in the eyes of payors and prescribers.
+
+4. **State-level mental health parity enforcement:** If enforced more aggressively, could expand access to branded antipsychotics. This is a potential positive structural shift but enforcement remains inconsistent.
+
+---
+
+## Key Monitoring Variables
+
+| Variable | Leading Indicator Of | Data Source | Threshold to Watch |
+|----------|---------------------|-------------|-------------------|
+| Weekly new-to-brand Rx (IQVIA/Symphony) | Commercial launch traction | IQVIA, Symphony Health | New branded antipsychotic needs 200+ NRx/week by month 6 to be on blockbuster trajectory |
+| Formulary wins (commercial top 10 PBMs) | Revenue potential ceiling | PBM formulary publications | Tier 2 preferred placement in 5+ of top 10 PBMs is minimum for commercial viability |
+| Medicaid open access policy changes | Volume potential in largest payor | State Medicaid bulletins | Any state switching from open access to restricted for antipsychotics |
+| Cobenfy bipolar I Phase III results | Competitive threat level | BMS clinical announcements | If approved for bipolar I, Cobenfy becomes the dominant competitive threat |
+| Generic iloperidone ANDA status | Fanapt revenue risk + BYSANTI narrative risk | FDA Orange Book / ANDA tracker | Any ANDA final approval triggers immediate competitive reassessment |
+| Big pharma M&A deal flow in psychiatry | Acquisition probability for small-cap assets | EY, Evaluate Pharma deal trackers | Continued >$20B annual CNS deal value supports acquisition optionality |
+| Gross-to-net spread trends | Net revenue realization | Company quarterly filings | Industry-wide branded antipsychotic gross-to-net widening beyond 55% signals payor pushback intensification |
+
+---
+
+## What Drives Profitability: First-Order vs. Second-Order Thinking
+
+| First-Order Observation | Second-Order Reality |
+|------------------------|---------------------|
+| "The antipsychotic market is $8B+ and growing at 6% CAGR" | Growth is concentrated in 3-4 branded drugs with novel profiles backed by large pharma. The market is not equally accessible to all entrants. |
+| "BYSANTI is a new chemical entity with patent protection to 2044" | NCE status provides regulatory and IP advantages, but clinical bioequivalence to Fanapt means payors will view it as a reformulation, not an innovation. The 2044 patent life protects a revenue stream that may remain small. |
+| "Two FDA approvals in two months signals pipeline productivity" | Two approvals signal regulatory execution, but commercial execution is a completely different capability. The gap between approval and commercial success is where most small-cap biotechs fail (63% of first-time launches underperform per McKinsey). |
+| "Psychiatry M&A is at all-time highs -- VNDA is an acquisition target" | M&A premiums are being paid for novel mechanisms and large TAMs, not for metabolite-derived antipsychotics. The J&J/Intra-Cellular and BMS/Karuna premiums reflected genuinely differentiated pharmacology. The relevant comp for a potential VNDA acquisition would be at a significant discount to those precedents. |
+| "Vanda already has 300 psychiatry sales reps" | 300 reps is meaningful but undersized relative to competitors. J&J, BMS, and AbbVie each field 1,000+ CNS reps. Alkermes has substantial infrastructure supporting Lybalvi. The existing sales force is necessary but not sufficient. |
+| "Unmet need in schizophrenia and bipolar I is enormous" | Unmet need is real, but it exists primarily in treatment adherence and treatment resistance -- areas where an oral drug bioequivalent to an existing agent does not represent a step-change. LAIs and novel mechanisms address unmet need more directly. |
+
+---
+
+## The Full-Cycle View: What History Teaches
+
+Studying the last full cycle of branded antipsychotic launches (2009-2025) reveals clear patterns:
+
+**Winners (>$1B peak US revenue):** Latuda, Vraylar, Caplyta (on trajectory), Rexulti. Common characteristics: novel or meaningfully differentiated receptor profiles, broad labels (multiple indications), large pharma commercial infrastructure (either at launch or via acquisition), formulary wins at scale.
+
+**Moderate successes ($200M-$1B):** Lybalvi (on trajectory at $350M). Characteristics: differentiated but derivative (olanzapine + opioid antagonist), strong pharma infrastructure (Alkermes), took 3+ years to reach current revenue.
+
+**Underperformers (<$200M):** Fanapt (iloperidone), Saphris (asenapine), Latuda early years. Characteristics: undifferentiated or poorly differentiated profiles, small company infrastructure, slow prescriber adoption, formulary challenges.
+
+**The base rate for a small-company-launched, non-novel-mechanism antipsychotic is $100-200M peak US revenue.** This is the historically grounded expectation absent extraordinary execution or acquisition.
+
+---
+
+## The Marginal Producer Question
+
+In the branded antipsychotic market, the "marginal producer" -- the branded drug that just barely justifies continued commercialization -- looks like:
+
+- $80-120M in annual US net revenue
+- $60-80M in annual SG&A to support commercial operations
+- Marginal profitability after full cost loading (breakeven to low single-digit operating margins)
+- Constant pressure from generic substitution and formulary displacement
+- Vulnerable to any competitive entry that fragments share further
+
+Fanapt, at $117M in 2025 revenue with ~300 sales reps, is operating near this marginal producer threshold. It is growing (24% YoY), but this growth required a doubling of sales force investment. The relevant question for BYSANTI is whether it can meaningfully exceed Fanapt's revenue trajectory given that it is pharmacologically bioequivalent to Fanapt.
+
+---
+
+## Industry Assessment Summary
+
+```
+INDUSTRY ASSESSMENT SUMMARY
+======================================================================
+Industry Structure:    NEUTRAL (favorable growth, but intensely competitive
+                       with large-cap consolidation of key branded positions)
+
+Cyclicality:           LOW (non-discretionary demand; relevant "cycle" is
+                       innovation/M&A enthusiasm, currently at PEAK)
+
+Current Position:      LATE CYCLE in psychiatry M&A/innovation enthusiasm
+                       MID-CYCLE in underlying antipsychotic demand growth
+
+Mid-Cycle Definition:  A branded antipsychotic entrant achieves $200-400M
+                       peak US revenue within 3-5 years of launch with
+                       adequate formulary access and $80-100M+ annual SG&A
+                       investment. Gross margins 70-85%, net margins
+                       20-40% at maturity. Gross-to-net realization 45-55%.
+
+Primary Industry Risk: Formulary restriction intensification -- payors
+                       increasingly steering to cheap generics via step
+                       therapy and prior authorization, structurally limiting
+                       the addressable market for branded entrants without
+                       genuinely novel mechanisms.
+
+Secondary Risk:        Competitive fragmentation -- 5+ branded antipsychotics
+                       simultaneously launching/growing fragments prescriber
+                       attention and formulary slots, reducing peak revenue
+                       potential for each individual drug vs. historical norms.
+======================================================================
+```
+
+### Industry Classification
+
+- **Structural trajectory:** MATURE GROWTH -- the overall market is growing (6% CAGR), but the branded segment is consolidating around large-pharma-backed assets with novel mechanisms. The derivative/lifecycle segment is mature and intensely competitive.
+- **Competitive structure:** CONSOLIDATING at the top (J&J, BMS, AbbVie control the top branded positions) while FRAGMENTED at the bottom (multiple small-cap branded entrants fighting for remaining share).
+
+### Sanity Check
+
+*If I knew nothing about any company in this industry, would industry economics alone make me cautious, comfortable, or excited about capital being deployed here?*
+
+**Cautiously comfortable at the industry level, but cautious about the specific competitive position available to a small-cap entrant with a non-novel mechanism.** The underlying market is growing, demand is non-discretionary, and psychiatry is attracting peak levels of pharma investment. However, the competitive landscape has never been more intense for branded antipsychotics, and the payor environment is structurally hostile to branded drugs without clear clinical differentiation from generics. The M&A tailwind is real but selectively rewarding -- it is paying premiums for novelty, not for all branded psychiatry assets equally.
+
+A new antipsychotic launch in 2026 is neither a great nor terrible time from an industry perspective. It is a **good time to be acquired** by a large pharma company seeking psychiatry assets (seller's market in M&A). It is a **challenging time to independently commercialize** against well-capitalized competitors with larger sales forces and more differentiated products.
+
+---
+
+## Key Sources
+
+- Fact.MR, Grand View Research, Mordor Intelligence: Antipsychotic and bipolar disorder market sizing
+- McKinsey & Company: "Small but mighty: Priming biotech first-time launchers" (November 2024); "First-time launchers in the pharmaceutical industry" (February 2021)
+- EY: 2025 pharma M&A deal value data (CNS/psychiatry overtaking oncology)
+- AJMC / JHEOR: Formulary restriction impact studies on antipsychotic access and outcomes (2025)
+- Alkermes, BMS, Vanda Pharmaceuticals: Quarterly earnings reports and financial guidance (2025)
+- FDA: Approval announcements for Cobenfy (September 2024), BYSANTI (February 2026)
+- Goldman Sachs: Pharma M&A outlook and "firepower" analysis
+- Consumer Edge / Earnest Analytics: Cobenfy launch tracking data
+- CATIE study: Antipsychotic discontinuation rates
+- HHS/ASPE: Access and utilization data for antipsychotic medications

--- a/claude/VNDA/memo.md
+++ b/claude/VNDA/memo.md
@@ -1,0 +1,290 @@
+# VNDA (Vanda Pharmaceuticals) -- CIO Investment Memo
+
+**Date:** 2026-02-23
+**Price:** ~$8.00/share (indicated open, +40% on BYSANTI FDA approval)
+**Market Cap:** ~$473M | **Enterprise Value:** ~$209M | **Net Cash:** $264M ($4.47/share)
+**Shares Outstanding:** 59.1M
+
+---
+
+## 1. RECOMMENDATION
+
+| | |
+|---|---|
+| **Decision** | **NEUTRAL (Too Hard at $8)** |
+| **Conviction** | Medium |
+| **Time Horizon** | N/A -- monitoring for entry at lower levels |
+| **Classification** | Too Hard / Conditional Buy at $6 or below |
+
+**The 40% gap is approximately right.** BYSANTI approval removes binary regulatory risk and that deserves a re-rating. But at $8, the stock is priced at fair value for what you can underwrite with confidence -- the existing business plus modest pipeline contribution. The upside from here requires you to trust an entrenched CEO with a documented record of value destruction to execute three simultaneous product launches against J&J, BMS, and AbbVie with a drug that payors have every reason to reject at branded pricing. The risk/reward at $8 is not asymmetric enough to warrant fresh capital. If it pulls back to $6-6.50, it becomes interesting. If BYSANTI shows early formulary wins and the MDD trial reads out positive in late 2026, it becomes very interesting at almost any price.
+
+---
+
+## 2. KEY DRIVERS (The 1-3 Things That Matter)
+
+**1. BYSANTI Formulary Access -- This Is the Entire Thesis**
+Can Vanda get BYSANTI on formularies without step-therapy requirements mandating generic iloperidone first? This single variable determines whether BYSANTI is a $50M product (Clarinex outcome) or a $300M+ product (differentiated franchise outcome). Generic iloperidone arrives late 2027/2028. Vanda has a 15-21 month window to establish BYSANTI before payors have a direct generic substitute for the exact same pharmacology. Every formulary negotiation outcome in Q3-Q4 2026 is a data point that moves the stock $2-4.
+
+**2. Cash Burn vs. Revenue Ramp Timing**
+$264M in cash, burning $120-150M/year, with management explicitly guiding for higher burn in 2026. A $200M shelf registration is filed and ready. The math is simple: if combined BYSANTI + NEREUS revenue does not materially inflect by mid-2027, Vanda raises equity at whatever price the market gives them. At $8 that is 15-25% dilution. At $5 it is catastrophic. The CEO has demonstrated he will not sell the company to avoid this outcome.
+
+**3. MDD Phase 3 Readout (End of 2026)**
+This is the binary event that transforms the thesis. If BYSANTI gets an MDD indication, it has a label that generic iloperidone does NOT have. That breaks the bioequivalence trap and gives payors a clinical reason to differentiate. If it fails, BYSANTI is permanently trapped in the Clarinex box -- an active metabolite evergreening play competing against its own generic parent. This trial result is worth $5-15/share in either direction.
+
+---
+
+## 3. THESIS IN 3-5 BULLETS
+
+- **The FDA approval is real but the commercial thesis is unproven.** BYSANTI removes regulatory risk but introduces commercial execution risk against the most competitive branded antipsychotic landscape in history. The market was right to re-rate the stock 40%, but the gap from $5.70 to $8 prices in approval, not commercial success.
+
+- **The bioequivalence that enabled approval is the commercial liability.** BYSANTI is pharmacologically identical to iloperidone. Payors will ask -- and are economically incentivized to enforce -- why they should pay branded pricing when generic iloperidone arrives in 18-21 months. Historical precedent (Clarinex, Nexium) is unfavorable for active metabolite evergreening in the absence of label differentiation.
+
+- **Management is the binding constraint, not the science.** The CEO rejected $8/share all-cash when the company had $375M in cash. Today the stock is $8 with $111M less cash. He has adopted a poison pill, amended bylaws to block shareholder action, filed a $200M shelf for dilutive financing, and escalated his own RSU grants into shareholder losses. Investors are paying for the science but receiving the governance.
+
+- **The MDD trial is the make-or-break catalyst.** Success creates genuine differentiation from generic iloperidone and opens a market 3-5x larger than bipolar I/schizophrenia. Failure locks BYSANTI into a category where it is structurally disadvantaged. This readout in late 2026 is the single most important event for VNDA shareholders.
+
+- **At $8, you are buying the existing business at roughly fair value with free pipeline optionality -- but optionality is worth less when the option holder (management) has a track record of misallocating capital.** The net cash floor of $4.47/share provides downside support, but that floor erodes by $2+/share per year at current burn rates.
+
+---
+
+## 4. VARIANT PERCEPTION TABLE
+
+| Market Believes | We Believe | Why Market Is Wrong | Novel Information Supporting Our View | What Changes Minds |
+|---|---|---|---|---|
+| BYSANTI approval = major commercial catalyst; 2044 patent = 18 years of protected revenue | BYSANTI approval removes regulatory risk but the 2044 patent protects against generic milsaperidone, NOT against generic iloperidone (arriving 2027-28) which is pharmacologically identical | The market conflates patent protection with commercial protection. A patent on the molecule is worthless if payors mandate step-therapy through a bioequivalent generic. The Clarinex precedent: 0.3% market share in managed formularies despite patent protection | Moat analyst identified that Clarinex (desloratadine, active metabolite of Claritin) achieved near-zero share in managed care. BYSANTI is structurally identical: active metabolite repackaged as NCE. Fanapt's own gross-to-net is already ~50%, indicating heavy rebating -- BYSANTI will face worse once generic iloperidone provides a cheaper substitute | First 2-3 quarters of formulary placement data (Q4 2026 / Q1 2027) showing either access or rejection |
+| Two approvals in 2 months = pipeline productivity = re-rate | Two approvals = two simultaneous launch cost burdens on a $216M revenue base already burning $120M+/year in cash | Market is celebrating regulatory execution but not pricing the commercial execution risk. McKinsey data: 63% of first-time launchers miss expectations. Vanda is attempting THREE simultaneous launches (BYSANTI, NEREUS, imsidolimab pending) which is unprecedented for a company this size | Capital allocation analyst surfaced that management guided 2026 cash burn will EXCEED 2025 ($110M+), and filed a $200M shelf the day after earnings. Management itself is telling you the cash math does not work without dilution | Cash balance trajectory through 2026; any equity offering announcement |
+| CEO rejected $8 offer because intrinsic value was higher -- now proven right by stock reaching $8 | CEO rejected $8 offer when company had $375M cash; stock now at $8 with $264M cash. Net asset value DECLINED $1.96/share in cash alone over 16 months. The CEO was wrong -- he destroyed $111M in shareholder cash to arrive at the same stock price | Market gives management credit for the stock recovering to $8 post-approval, ignoring that $111M in cash was consumed to get here. The offer was at a $6.43/share cash floor; today's cash floor is $4.47. Shareholders are objectively worse off | Capital allocation analyst documented: $182M cash decline over 4 years, 5.7% share dilution, zero buybacks, zero dividends, poison pill adoption, bylaw amendments to block activist shareholders. This is a pattern, not an isolated incident | An activist gaining board representation, or management voluntarily initiating a strategic review |
+| GLP-1 nausea option (NEREUS/tradipitant) adds significant optionality | GLP-1 nausea is real but Phase 2 only, and Vanda has zero consumer/DTC marketing capability. The motion sickness base indication alone may struggle against OTC alternatives | The GLP-1 option is genuinely interesting science but requires: (a) a Phase 3 trial not yet started, (b) a commercial model Vanda has never executed (consumer/DTC), (c) 2-3 more years of development. Discounting at 12% with 30-40% probability of success, the option is worth $1-3/share, not the $5-10 some bulls suggest | Industry analyst noted NEREUS enters a consumer/OTC-adjacent market where Vanda has no experience. Financial analyst estimated NEREUS peak at $100-200M but assigned only medium-low confidence | Phase 3 GLP-1 nausea trial initiation and design (H1 2026); early NEREUS motion sickness prescription data |
+
+---
+
+## 5. THE SETUP
+
+Vanda Pharmaceuticals is a commercial-stage specialty pharma company that just secured its second FDA approval in two months. The business generates $216M in annual revenue from three marketed products (Fanapt, HETLIOZ, PONVORY), has $264M in net cash, and now holds five approved drugs with a pipeline catalyst (MDD Phase 3) due in late 2026.
+
+The structural forces at play are in tension:
+
+**Favorable:** Psychiatry M&A cycle at peak ($30.7B in CNS deal value in 2025, overtaking oncology). Vanda is a potential acquisition target in a seller's market. The company has existing commercial infrastructure (300 reps) and growing Fanapt revenue ($117M, +24% YoY). BYSANTI's 2044 patent and NCE status provide fresh regulatory exclusivity.
+
+**Unfavorable:** The branded antipsychotic market has never been more competitive. J&J (Caplyta, $680M revenue), BMS (Cobenfy, novel mechanism), AbbVie (Vraylar, $2.5B+) all field 1,000+ rep sales forces. BYSANTI is pharmacologically bioequivalent to a molecule (iloperidone) that achieved only $117M in sales after 16 years on market. Generic iloperidone arrives 2027-2028, giving payors direct ammunition to impose step therapy. The company is burning $120M+/year with a CEO who has rejected premium acquisition offers, adopted entrenchment devices, and filed a $200M shelf for dilutive financing.
+
+The central tension: **BYSANTI's regulatory success was enabled by its bioequivalence to iloperidone. BYSANTI's commercial success is threatened by that same bioequivalence.** The molecule that made FDA approval efficient makes commercial differentiation nearly impossible -- unless the MDD indication or LAI formulation provides separation.
+
+---
+
+## 6. NUMBERS THAT MATTER
+
+### What $8/Share Implies
+
+| Metric | Value |
+|---|---|
+| Enterprise value | ~$209M |
+| EV / FY2025 revenue ($216M) | 0.97x |
+| EV / FY2026E revenue (consensus ~$271M) | 0.77x |
+| Net cash as % of market cap | 56% |
+
+At $8, the market is pricing the entire operating business -- $216M revenue, two fresh approvals, pipeline, 300-person sales force -- at $209M EV, or less than 1x current revenue. For a 94% gross margin specialty pharma company, this is optically cheap. The question is whether the operating business deserves more.
+
+### Normalized Earnings Framework
+
+The financial analyst's work here is critical. At its pre-investment cost structure, Vanda was roughly breakeven on $216M revenue. The current $220M GAAP loss is almost entirely investment-phase spending ($130M excess SG&A/R&D) and a $114M non-cash tax allowance.
+
+**Forward normalized earnings power (base case, ~$500-600M peak revenue):**
+
+| Item | Amount |
+|---|---|
+| Peak revenue (Fanapt $170M + BYSANTI $200M + HETLIOZ $45M + PONVORY $40M + NEREUS $100M) | ~$555M |
+| Operating margin at maturity | 35-40% |
+| Normalized operating income | $195-220M |
+| After-tax earnings (21% rate) | $155-175M |
+| Per share (~62M diluted) | $2.50-2.80 |
+
+At 12-15x normalized earnings, that implies $30-42/share -- but this is 4-5 years away and requires successful execution of multiple launches.
+
+### Scenario Framework
+
+| Scenario | Probability | Key Assumption | Fair Value/Share |
+|---|---|---|---|
+| **Skeptical Bear** | 20% | BYSANTI flops (Clarinex outcome), NEREUS disappoints, dilutive raise at $5 | **$5-7** |
+| **Base Case** | 45% | BYSANTI reaches $150-250M peak (modest formulary access), NEREUS at $75-125M, one dilutive raise | **$15-22** |
+| **Bull Case** | 25% | BYSANTI MDD success, $350M+ peak, NEREUS GLP-1 option hits, M&A or strategic partnership | **$30-45** |
+| **Takeout** | 10% | Acquired at 3-5x forward revenue during psychiatry M&A wave | **$25-40** |
+| **Probability-Weighted** | | | **$16-22** |
+
+### My Numbers vs. the Financial Analyst's Numbers
+
+The financial analyst arrived at ~$33/share probability-weighted fair value. I am materially lower at $16-22 for three reasons:
+
+1. **I assign higher probability to the skeptical bear case (20% vs. 15%).** The payor dynamics the moat analyst surfaced -- Clarinex precedent, 50% gross-to-net on Fanapt already, generic iloperidone arriving in 18-21 months -- are more severe commercial headwinds than the financial analyst incorporated. The financial analyst's "bear case" at $20/share requires BYSANTI to reach $150M, which I consider the base case, not the bear case.
+
+2. **I apply a governance/dilution discount.** The capital allocation analyst documented a CEO who rejected $8/share with $375M cash and now presides over $8/share with $264M cash. A $200M shelf is filed. Near-certain dilution of 15-25% within 12-18 months is not fully reflected in the financial analyst's per-share values. I use 62-65M diluted shares vs. 59M.
+
+3. **I use the industry analyst's base rate for peak BYSANTI revenue.** "The base rate for a small-company-launched, non-novel-mechanism antipsychotic is $100-200M peak US revenue." The financial analyst's base case of $300M for BYSANTI is above this base rate. I center on $150-250M.
+
+### What Must Be True for $8 to Be Right
+
+For $8/share to be fair value, you need to believe:
+- BYSANTI generates essentially zero incremental revenue beyond Fanapt cannibalization
+- NEREUS is a commercial failure
+- The company raises dilutive equity at depressed prices
+- HETLIOZ continues collapsing
+- Fanapt growth stalls as generic iloperidone arrives
+
+This is the deeply pessimistic scenario. $8 is pricing in roughly the 15th-20th percentile outcome. That is cheap, but not cheap enough to overcome the governance discount and execution uncertainty.
+
+### What Must Be True for $20+ to Be Right
+
+- BYSANTI achieves $150M+ in peak sales with adequate formulary access
+- No more than one dilutive raise, at $8+ per share
+- Operating margins normalize to 30%+ at $400M+ revenue
+- MDD trial success is not required but would be a bonus
+
+These are plausible but far from certain. The 15-21 month window before generic iloperidone is the binding constraint.
+
+---
+
+## 7. FORWARD PATH AND CATALYSTS
+
+### Near-Term (0-6 Months)
+- **BYSANTI commercial launch (Q3 2026):** First formulary placement announcements will be the most important data points. Watch for Tier 2 preferred placement in top 10 PBMs. If BYSANTI lands on 5+ major formularies without step-therapy, the bull case is alive.
+- **NEREUS commercial launch (Q2-Q3 2026):** First prescription data. Base rate for motion sickness is unknown -- this is a new category. Watch weekly NRx trajectory.
+- **Q1/Q2 2026 earnings:** Cash burn trajectory. If burn is tracking >$130M annualized, equity raise is imminent.
+- **Imsidolimab PDUFA:** BLA submitted Dec 2025. Potential approval in H2 2026. Orphan drug with high margins if approved.
+
+### Medium-Term (6-18 Months)
+- **MDD Phase 3 readout (end of 2026):** THE binary catalyst. Success = BYSANTI differentiation from generic iloperidone = re-rate to $15-25. Failure = BYSANTI trapped as Clarinex = de-rate to $5-7.
+- **Generic iloperidone entry (late 2027 / May 2028):** This is the competitive clock. Once generic iloperidone is available, every BYSANTI formulary negotiation becomes harder.
+- **Equity offering:** Near-certain within 12-18 months. Size and pricing will determine dilution impact.
+- **M&A interest:** Psychiatry M&A cycle remains hot. Any inbound interest is a catalyst, though the CEO has demonstrated willingness to reject premium offers.
+
+### What the Market Will Notice Next
+The market is currently celebrating the approval. It will next focus on:
+1. BYSANTI pricing announcement (expected before Q3 2026 launch)
+2. First formulary access disclosures
+3. Cash burn in Q1-Q2 2026 relative to guidance
+4. Any equity offering filing
+
+---
+
+## 8. RISKS AND KILL SWITCHES
+
+### What Invalidates the Thesis
+- **Formulary rejection at scale.** If 3+ of the top 5 PBMs impose step-therapy requiring generic iloperidone before BYSANTI, the commercial thesis is dead. Peak BYSANTI revenue would be sub-$100M and Vanda becomes a value trap burning cash.
+- **MDD Phase 3 failure.** Removes the differentiation pathway. BYSANTI becomes permanently trapped as an active metabolite evergreening play.
+- **Dilutive raise below $6.** If management raises equity at depressed prices (which they will, given the shelf filing and burn rate), the per-share value destruction compounds. A $150M raise at $5 adds 30M shares -- 50% dilution.
+
+### What Causes Permanent Capital Loss
+- **Management entrenchment + failed launches + dilutive financing spiral.** The CEO will not sell. If launches fail, he will raise equity to keep the company alive, diluting shareholders. If that equity raise buys 12-18 months and launches still fail, he will raise again. This is the terminal scenario: a slow bleed of shareholder value through repeated dilution while the CEO collects $4M+/year in compensation. The poison pill and bylaw amendments ensure shareholders cannot force a change.
+
+### What Forces Re-evaluation
+- BYSANTI pricing announced at >$15K/year (signals aggressive positioning that may trigger payor resistance)
+- Cash burn in Q1 2026 exceeding $40M (implies >$160M annualized, accelerating the dilution timeline)
+- CEO making any additional entrenchment moves (new poison pill terms, further bylaw restrictions)
+- Generic iloperidone ANDA receiving final FDA approval earlier than expected
+
+---
+
+## 9. POSITIONING AND PORTFOLIO LOGIC
+
+### Why Not Now
+
+At $8, the risk/reward is roughly symmetric: probability-weighted fair value of $16-22 implies 100-175% upside, but the skeptical bear at $5-7 implies 15-35% downside, and the path to fair value requires 2-3 years of execution by a management team with a weak capital allocation record. The asymmetry is insufficient for a position in a stock where:
+- The CEO is demonstrably entrenched and self-dealing
+- Dilution is near-certain and could be 15-25%
+- The core product (BYSANTI) faces a structural commercial headwind (bioequivalence to impending generic)
+- Three simultaneous launches create execution complexity unprecedented for a company this size
+
+### What Would Make This a Buy
+
+| Trigger | Entry Price | Position Size | Rationale |
+|---|---|---|---|
+| Stock pulls back to $6-6.50 on post-gap fade | $6-6.50 | 1% starter | Net cash floor of $4.47 provides 30% downside support; EV collapses to $90-120M on $216M revenue |
+| BYSANTI formulary wins at 3+ top PBMs without step-therapy | Market price | 1.5-2% | Removes the #1 risk; commercial thesis validated |
+| MDD Phase 3 success | Market price | 2-3% core | Transforms BYSANTI from Clarinex to differentiated franchise; worth $5-15/share in re-rating |
+| Activist gains board seat or strategic review announced | Market price | 2% | Governance discount narrows; M&A optionality monetized |
+
+### What I Would Pair or Hedge
+
+If entering a position, I would consider:
+- **Short SUPN (Supernus) as a pair trade:** Both are small-cap CNS/psychiatry names. SUPN trades at 4x forward revenue vs. VNDA at <1x. If psychiatry sentiment sours, both decline, but VNDA's net cash provides a harder floor.
+- **Put protection:** If June/September 2026 puts are available at reasonable vol, buying $6 strike puts to define downside around a dilutive equity raise.
+
+### Post-Entry Monitoring
+
+| Signal | Action |
+|---|---|
+| BYSANTI NRx/week >150 by month 3 | Add to position -- commercial traction emerging |
+| BYSANTI NRx/week <50 by month 3 | Cut position in half -- Clarinex scenario materializing |
+| Equity offering announced at <$6 | Exit entirely -- dilution spiral beginning |
+| MDD Phase 3 positive | Add to full size (3%) -- thesis transformation |
+| MDD Phase 3 negative | Cut to 0.5% monitoring position |
+| CEO rejects another acquisition offer | Exit entirely -- governance discount should be permanent |
+
+---
+
+## 10. ANSWERING THE USER'S QUESTION: "WHAT'S IT REALLY WORTH?"
+
+### The Honest Answer
+
+**It depends on which BYSANTI shows up.**
+
+| BYSANTI Outcome | VNDA Fair Value | Probability |
+|---|---|---|
+| Clarinex (payor rejection, <$100M peak) | $5-8/share | 20% |
+| Modest success ($150-250M peak, no MDD) | $15-22/share | 45% |
+| Franchise drug ($300M+ peak, MDD success) | $30-45/share | 25% |
+| Acquisition target | $25-40/share | 10% |
+| **Probability-weighted** | **$16-22/share** | |
+
+**At $8, the stock is cheap but not a screaming buy.** You are paying roughly the skeptical bear case price for a business with meaningful upside optionality. The problem is that the optionality is controlled by a CEO who has demonstrated he will not sell and may dilute you to fund execution.
+
+### Is the 40% Gap Overdone, About Right, or Not Enough?
+
+**About right.** The move from $5.70 to $8 represents approximately:
+- Removal of binary FDA risk on BYSANTI (worth $1-2/share)
+- Validation of pipeline productivity (two approvals in two months)
+- Market recognizing the net cash floor ($4.47/share) should be higher given reduced pipeline risk
+
+The stock would need to sustain above $10-12 to signal the market is pricing in actual commercial success, not just approval. At $8, you are paying for approval but not for launch.
+
+### The Uncomfortable Truth
+
+Sixteen months ago, Cycle Pharmaceuticals offered $8/share in cash with certainty. Shareholders who held through the decline to $3.81 and back are now at exactly the same price -- but the company has $111M less cash. The CEO's decision to reject that offer cost shareholders $1.96/share in net cash value. Now he needs those shareholders to trust him with three simultaneous product launches, a $200M shelf registration, and a 15-21 month window before generic competition arrives for his flagship product.
+
+That is a lot of trust for a management team that has earned very little of it.
+
+---
+
+## RECONCILIATION OF SPECIALIST INPUTS
+
+### Where Specialists Agree
+All four specialists converge on: (a) the existing business at $216M revenue provides a real floor, (b) the balance sheet is adequate but eroding, (c) BYSANTI's bioequivalence to iloperidone is a double-edged sword, and (d) the MDD trial is the pivotal catalyst.
+
+### Where Specialists Disagree
+- **Financial analyst** sees $33/share probability-weighted fair value. This is the most bullish input and assumes BYSANTI at $300M peak (above industry base rate) with limited dilution.
+- **Moat analyst** rates the moat WEAK and earnings durability LOW. This is the most bearish structural input -- the bioequivalence trap is real and the Clarinex precedent is directly applicable.
+- **Industry analyst** provides the base rate: $100-200M peak for a small-company non-novel antipsychotic. This is the most grounding input and anchors my BYSANTI estimate below the financial analyst's.
+- **Capital allocation analyst** surfaces the governance risk that the financial analyst underweights: management has destroyed $182M in cash over 4 years, rejected premium offers, adopted entrenchment devices, and filed for dilutive financing.
+
+### How I Reconcile
+I weight the moat analyst's bioequivalence concern and the industry analyst's base rate more heavily than the financial analyst's bull case. The financial analyst's work on normalized earnings and valuation mechanics is excellent, but it assumes commercial outcomes that the other three analysts raise serious questions about. The capital allocation analyst's governance concerns are the most underappreciated risk -- this is a stock where the management discount should be 15-25% of intrinsic value, and I apply it.
+
+**Net result:** I arrive at $16-22/share probability-weighted fair value vs. the financial analyst's $33. The difference is almost entirely explained by: (a) lower BYSANTI peak revenue assumption ($150-250M vs. $300M), (b) a governance/dilution discount, and (c) higher weight on the skeptical bear case.
+
+---
+
+## BOTTOM LINE
+
+VNDA at $8 is not a buy. It is a stock to own at $6 or upon proof of BYSANTI commercial traction, whichever comes first. The FDA approval is genuinely positive, but the market has appropriately re-priced it. The path from $8 to $20+ requires BYSANTI to overcome a structural commercial headwind (bioequivalence to impending generic), a hostile payor environment, a competitive landscape dominated by companies 50-100x Vanda's size, and a CEO whose track record on capital allocation is among the worst I have reviewed. That is too many things that need to go right for a stock trading at fair-to-slightly-cheap on my numbers.
+
+The MDD readout in late 2026 is the catalyst that changes everything. If it succeeds, BYSANTI breaks free from the bioequivalence trap and VNDA re-rates to $20-30+. If it fails, BYSANTI is Clarinex and VNDA trades to $5-7 as the dilutive financing spiral begins.
+
+**Pass for now. Monitor for entry. The science is interesting but the jockey is not trustworthy.**
+
+---
+
+*Specialist analyses referenced:*
+- `/home/user/models/claude/VNDA/rigorous-financial-analyst.md`
+- `/home/user/models/claude/VNDA/business-moat-analyst.md`
+- `/home/user/models/claude/VNDA/industry-structure-cycle-analyst.md`
+- `/home/user/models/claude/VNDA/capital-allocation-analyst.md`

--- a/claude/VNDA/rigorous-financial-analyst.md
+++ b/claude/VNDA/rigorous-financial-analyst.md
@@ -1,0 +1,419 @@
+# VNDA (Vanda Pharmaceuticals) -- Rigorous Financial Analysis
+
+**Date:** 2026-02-23
+**Price:** ~$8.00/share (indicated open, +40% from prior close of ~$5.70)
+**Market Cap:** ~$473M at $8.00 (59.1M shares)
+**Enterprise Value:** ~$209M (market cap minus $264M net cash)
+**Catalyst:** FDA approval of BYSANTI (milsaperidone) on 2026-02-20 -- second approval in <2 months
+
+---
+
+## CRITICAL CORRECTION: THIS IS NOT A PRE-REVENUE COMPANY
+
+The premise that VNDA had "no reported TTM revenue prior to these approvals" is factually wrong. Vanda generated **$216.1M in FY2025 revenue** from three marketed products (Fanapt, HETLIOZ, PONVORY) and had **$198.8M in FY2024 revenue**. This fundamentally changes the analytical framework: VNDA is not a binary biotech play. It is a **commercial-stage specialty pharma company** entering a pipeline inflection. The existing revenue base is the floor; the pipeline approvals (NEREUS, BYSANTI) are the upside.
+
+---
+
+## 1. BUSINESS FINANCIAL PROFILE
+
+| Attribute | Assessment |
+|---|---|
+| Capital intensity | Very low (capex ~$0.5M-1.1M/yr) |
+| Cost structure | Predominantly fixed (300-person Fanapt sales force, 50-person Ponvory team) |
+| Operating leverage | High -- revenue growth falls almost entirely to the bottom line once SGA is scaled |
+| Cyclicality | Non-cyclical (psychiatric/neurologic chronic conditions) |
+| Revenue quality | Mixed -- Fanapt growing (+24% YoY), HETLIOZ declining (-7% YoY from generic erosion) |
+| Revenue durability | BYSANTI patent through 2044; Fanapt facing eventual generic risk; HETLIOZ already genericized |
+
+---
+
+## 2. INCOME STATEMENT ANALYSIS
+
+### Revenue Trends (Quarterly, per Earnings Releases)
+
+| Quarter | Fanapt | HETLIOZ | PONVORY | Total | YoY Growth |
+|---|---|---|---|---|---|
+| Q1 2024 | $21.2M | $19.3M | $7.1M | $47.6M | -- |
+| Q2 2024 | $20.0M | $17.4M | $7.0M | $44.4M | -- |
+| Q3 2024 | $23.8M | $17.8M | $5.8M | $47.7M | -- |
+| Q4 2024 | $26.6M | $20.0M | $6.5M | $53.2M | +17% |
+| Q1 2025 | $24.1M | $19.2M | $5.7M | $49.0M | +3% est |
+| Q2 2025 | $28.8M | $17.8M | $7.1M | $53.7M | +21% est |
+| Q3 2025 | $31.2M | $18.0M | $7.0M | $56.3M | +18% |
+| Q4 2025 | $33.2M | $16.4M | $7.6M | $57.2M | +8% |
+| **FY2024** | **$94.3M** | **$76.7M** | **$27.8M** | **$198.8M** | +3% |
+| **FY2025** | **$117.3M** | **$71.4M** | **$27.4M** | **$216.1M** | +9% |
+
+### Operating Expense Trends
+
+| Item | FY2024 | FY2025 | YoY Change |
+|---|---|---|---|
+| COGS (excl. amortization) | $8.6M est | $13.0M | +51% |
+| R&D | $62.5M est | $109.3M | +75% |
+| SG&A | $153.5M est | $238.0M | +55% |
+| Intangible amortization | $7.0M est | $7.0M | flat |
+| **Total operating expenses** | **$239.4M** | **$367.3M** | **+53%** |
+| **Operating loss** | **$(40.6M)** | **$(151.2M)** | -- |
+
+### Margin Profile
+
+| Metric | FY2023 | FY2024 | FY2025 |
+|---|---|---|---|
+| Gross margin (excl. amort) | ~95% | ~96% | ~94% |
+| R&D as % of revenue | ~28% est | ~31% | 51% |
+| SG&A as % of revenue | ~72% est | ~77% | 110% |
+| Operating margin | -- | (20%) | (70%) |
+| GAAP net margin | 1.3% | (9.5%) | (102%) |
+
+**Key observation:** SG&A and R&D spending exploded in FY2025 as Vanda simultaneously expanded the Fanapt sales force from 160 to 300 reps, invested in imsidolimab licensing ($15M upfront to AnaptysBio), and funded multiple clinical programs. This spending is investment-phase, not steady-state. The GAAP net loss of $220.5M is misleading because it includes a $113.7M non-cash tax valuation allowance.
+
+---
+
+## 3. CASH FLOW AND NORMALIZED EARNINGS
+
+### Historical Free Cash Flow
+
+| Metric | FY2021 | FY2022 | FY2023 | FY2024 | FY2025 (est) |
+|---|---|---|---|---|---|
+| Operating cash flow | $64.2M | $32.0M | $12.8M | $(15.8M) | ~$(110M) |
+| Capex | $(0.6M) | $(0.7M) | $(0.4M) | $(0.5M) | ~$(1.1M) |
+| **Free cash flow** | **$63.6M** | **$31.3M** | **$12.4M** | **$(16.2M)** | **~$(111M)** |
+
+Sources: Yahoo Finance cash flow data; FY2025 estimated from year-end cash decline of $110.8M adjusted for investment flows.
+
+### GAAP-to-Normalized Earnings Bridge (FY2025)
+
+| Line Item | Amount | Notes |
+|---|---|---|
+| GAAP net loss | $(220.5M) | Per FY2025 earnings release |
+| Add back: Tax valuation allowance | +$113.7M | One-time non-cash charge against deferred tax assets |
+| Non-GAAP net loss (company-reported) | $(106.8M) | Per company disclosure |
+| Add back: SBC expense | +$10-15M est | Estimated from ~$15M unrecognized cost as of Q3 2025 |
+| Add back: Excess investment-phase R&D | +$45M est | R&D was $109M vs ~$65M normalized (imsidolimab license, Phase 3 programs) |
+| Add back: Excess investment-phase SGA | +$85M est | SGA was $238M vs ~$153M normalized (sales force buildout, pre-launch spend) |
+| Less: Tax effect on add-backs (21%) | $(29M) est | Applying statutory rate |
+| **Normalized net loss (current revenue base)** | **~$(0-5M)** | Approximately breakeven on current $216M revenue at steady-state cost structure |
+
+**What this means:** At its existing ~$216M revenue base and a normalized cost structure (pre-investment-phase), Vanda was roughly a breakeven business. The 2025 loss is almost entirely attributable to deliberate investment spending to support multiple launches. This is the correct baseline -- not the $220M GAAP loss.
+
+### Normalized Steady-State Earnings Power (Forward-Looking)
+
+This is the critical question: what does VNDA earn at maturity with its current and approved products?
+
+**Revenue assumptions (peak, ~2029-2030):**
+
+| Product | Peak Revenue Est | Confidence | Rationale |
+|---|---|---|---|
+| Fanapt (bipolar I + schizophrenia) | $170-200M | High | Already at $117M growing 24% YoY; 300-rep sales force; 2026 guidance $150-170M |
+| BYSANTI (bipolar I + schizophrenia) | $200-400M | Medium | NCE with 2044 patent; same efficacy as Fanapt but branded exclusivity; cannibalization risk vs Fanapt partially offset by broader prescriber base and potential MDD indication |
+| HETLIOZ (Non-24) | $40-50M | Medium | Declining from $71M due to generics; floor likely ~$40-50M as branded retention remains high after 3+ yrs of generic competition |
+| PONVORY (MS) | $35-50M | Medium | Growing modestly; specialty sales force in place |
+| NEREUS (motion sickness) | $100-200M | Medium-Low | First-in-class in 40 years; $670M TAM; analyst range $100-300M; OTC competition; NK-1 pricing $200-600/dose |
+| Imsidolimab (GPP) | $50-150M | Low | Rare disease orphan pricing; BLA filed Dec 2025; small patient population but premium pricing |
+
+**Base case peak revenue: $600-800M** (using midpoints)
+**Bull case peak revenue: $900-1,050M** (management targets $750M+ from psychiatry alone by 2030)
+**Bear case peak revenue: $400-500M** (Fanapt/BYSANTI cannibalization, weak NEREUS uptake, imsidolimab rejection)
+
+**Normalized peak earnings power (base case ~$700M revenue):**
+
+| Item | Amount | % of Revenue |
+|---|---|---|
+| Net revenue | $700M | 100% |
+| COGS | $(42M) | 6% |
+| R&D (maintenance + ongoing) | $(70M) | 10% |
+| SG&A (normalized, ~350-400 reps) | $(280M) | 40% |
+| Intangible amortization | $(7M) | 1% |
+| **Operating income** | **$301M** | **43%** |
+| Interest/other income | $5M | -- |
+| Taxes (21%) | $(64M) | -- |
+| SBC (deducted as real cost) | $(20M) est | -- |
+| **Normalized after-tax earnings** | **~$222M** | **32%** |
+| Shares outstanding (est. ~62M with dilution) | -- | -- |
+| **Normalized EPS** | **~$3.58/share** | -- |
+
+**Why these margin assumptions are reasonable:**
+- Specialty pharma gross margins of 93-94% are standard for branded oral drugs with minimal COGS.
+- SGA at 40% of revenue is the mature specialty pharma benchmark; Supernus runs at ~40-45%.
+- R&D at 10% is appropriate for a company maintaining existing programs post-launch, with selective pipeline investment.
+- 43% operating margin at scale is consistent with mature branded specialty pharma (SUPN targets similar margins on its growth trajectory).
+
+---
+
+## 4. BALANCE SHEET AND FINANCIAL RISK
+
+### Current Position (December 31, 2025)
+
+| Item | Amount |
+|---|---|
+| Cash and equivalents | $84.9M |
+| Marketable securities | $179.0M |
+| **Total liquid assets** | **$263.8M** |
+| Total assets | $488.9M |
+| Total liabilities | $161.7M est |
+| Stockholders' equity | $327.2M |
+| Total debt | **$0** |
+| **Net cash** | **$263.8M** |
+| Net cash per share | **$4.47/share** |
+
+Sources: FY2025 earnings release, February 11, 2026.
+
+### Cash Runway Analysis
+
+| Scenario | Annual Cash Burn | Runway (Months) | Dilution Needed? |
+|---|---|---|---|
+| Status quo (no NEREUS/BYSANTI revenue) | ~$120-130M | ~24 months | Likely by late 2027 |
+| Base case (NEREUS/BYSANTI revenue ramps Q3 2026) | ~$80-100M net in 2026, declining thereafter | 30+ months | Probably not |
+| Bull case (fast uptake, Fanapt growth continues) | Cash flow positive by late 2027 | Indefinite | No |
+
+**Critical point:** Vanda's 2026 guided revenue of $230-260M from existing products alone covers a significant portion of operating expenses. The $264M cash cushion provides real runway. The question is whether BYSANTI and NEREUS ramp fast enough to close the gap before cash runs out.
+
+**Key risk:** Management stated 2026 cash burn will **exceed** 2025 levels. This means potentially $120-150M in cash usage, bringing year-end 2026 cash to $115-145M. At that point, one more heavy burn year without revenue inflection would necessitate financing.
+
+### Milestone Payments
+
+- $10M to Eli Lilly for NEREUS approval (payable Q1 2026)
+- Up to $35M in potential milestones to AnaptysBio for imsidolimab (regulatory + sales-based)
+- Potential milestone payments for Fanapt LAI program (terms not disclosed)
+
+---
+
+## 5. CAPITAL ALLOCATION ASSESSMENT
+
+| Metric | Assessment |
+|---|---|
+| Reinvestment rate | Extremely high -- 170% of revenue spent on opex in FY2025 |
+| M&A discipline | Mixed -- PONVORY acquired Dec 2023 ($27M revenue, growth modest); imsidolimab license $15M upfront + milestones; both are reasonable bolt-on deals |
+| Buybacks vs. issuance | Minimal -- no significant buybacks; share count stable at ~59M; RSU/PSU grants ~1M shares/year to executives |
+| Incremental ROIC | Not yet calculable -- company is in investment phase |
+
+**Dilution trajectory:** Share count has been stable (~59M). Annual SBC-related dilution is modest at ~1-1.5M shares/year (1.7-2.5% dilution). This is manageable and does not represent a red flag.
+
+---
+
+## 6. RED FLAGS CHECKLIST
+
+- [X] **Persistent negative free cash flow** -- FCF turned negative in FY2024, deeply negative in FY2025. However, this is driven by deliberate investment spending for multiple product launches, not structural unprofitability. The pre-investment FCF was +$64M in FY2021 on lower revenue. PARTIALLY MITIGATED.
+- [ ] Rising SBC as % of revenue -- SBC is estimated at ~$10-15M on $216M revenue (5-7%). Modest and not trending sharply higher.
+- [X] **Margin expansion driven by accounting choices** -- The $113.7M tax valuation allowance in FY2025 distorts reported results. Management's "non-GAAP" net loss of $106.8M strips this out, which is appropriate. However, operating expenses are genuinely elevated, not accounting fiction.
+- [X] **Weak cash conversion** -- FY2025 GAAP loss of $220M vs. estimated operating cash burn of ~$111M. The divergence is largely the tax valuation allowance ($114M non-cash). Cash conversion was reasonable pre-investment-phase.
+- [ ] Balance sheet fragility -- No. $264M net cash, zero debt. Balance sheet is strong for a company this size.
+- [ ] Aggressive revenue recognition -- No evidence. Revenue is straightforward product sales.
+- [ ] Related party transactions -- None flagged.
+
+---
+
+## 7. VALUATION FRAMEWORK
+
+### What $8/Share Implies
+
+| Metric | Value at $8/Share |
+|---|---|
+| Market cap | ~$473M |
+| Less: Net cash ($264M) | -- |
+| Enterprise value | **~$209M** |
+| EV / FY2025 revenue ($216M) | **0.97x** |
+| EV / FY2026E revenue (guidance midpoint $245M) | **0.85x** |
+| EV / FY2026E revenue (consensus $271M) | **0.77x** |
+| Implied value of pipeline (above existing product value) | See below |
+
+At $8/share, the market is **barely paying for the existing revenue base.** An EV/revenue of 0.85-0.97x for a specialty pharma company with 94% gross margins, growing revenue, and two freshly approved drugs with 18+ years of patent life is deeply discounted.
+
+For context: Supernus (SUPN) trades at <4x forward P/S. J&J paid 14.6x forward revenue for Intra-Cellular (ITCI/CAPLYTA). Even distressed specialty pharma companies trade at 1-2x revenue.
+
+### Risk-Adjusted NPV Framework
+
+I model three scenarios with a 12% discount rate (appropriate for small-cap specialty pharma commercial-stage risk).
+
+#### Bear Case (25% probability)
+
+- Fanapt peaks at $170M, BYSANTI at $150M (heavy cannibalization), HETLIOZ floors at $45M
+- PONVORY at $35M, NEREUS at $75M, imsidolimab not approved
+- Peak revenue: ~$475M by 2029
+- Peak operating income: ~$150M (32% margin -- lower due to sub-scale)
+- Terminal multiple: 10x operating income = $1.5B EV
+- Discounted at 12% over 4 years = ~$950M PV of EV
+- Plus net cash: $264M
+- **Bear case equity value: ~$1.2B = ~$20/share**
+
+Wait -- this "bear case" already implies significant upside from $8. Let me re-examine with a more conservative lens.
+
+#### Deeply Skeptical Bear Case (15% probability)
+
+- BYSANTI flops commercially (no differentiation vs. generic iloperidone, payers resist)
+- NEREUS disappoints (OTC competition, narrow indication)
+- HETLIOZ collapses to $25M from accelerated generic erosion
+- Imsidolimab rejected
+- Peak revenue: $280M (basically Fanapt growth + modest PONVORY)
+- Operating margin: 15% (can't reduce sales force fast enough)
+- Operating income: $42M
+- Terminal multiple: 8x = $336M EV
+- Plus net cash (lower, ~$150M after continued burn): $486M
+- **Skeptical bear equity value: ~$486M = ~$8.20/share**
+
+This is where $8/share prices you: a scenario where virtually everything goes wrong except Fanapt.
+
+#### Base Case (45% probability)
+
+- Fanapt: $180M, BYSANTI: $300M, HETLIOZ: $45M, PONVORY: $40M, NEREUS: $150M, imsidolimab: $75M
+- Peak revenue: ~$790M by 2030
+- Operating margin: 40% at maturity
+- Operating income: $316M
+- Terminal multiple: 12x (appropriate for diversified specialty pharma with patent runway)
+- Terminal value: $3.79B
+- Discounted at 12% over 5 years: ~$2.15B PV
+- Plus net cash: $264M (adjusted down for interim losses)
+- Adjusted net cash by 2030: assume breakeven on cumulative basis, ~$150M
+- **Base case equity value: ~$2.3B = ~$37/share**
+
+#### Bull Case (15% probability)
+
+- Fanapt: $200M, BYSANTI: $450M (including MDD indication), HETLIOZ: $50M, PONVORY: $50M, NEREUS: $250M (GLP-1 nausea indication), imsidolimab: $150M (GPP + expansion)
+- Peak revenue: ~$1.15B
+- Operating margin: 45%
+- Operating income: $518M
+- Terminal multiple: 14x
+- Terminal value: $7.25B
+- Discounted at 12% over 5 years: ~$4.1B PV
+- **Bull case equity value: ~$4.3B = ~$69/share**
+
+### Probability-Weighted Fair Value
+
+| Scenario | Probability | Value/Share | Weighted |
+|---|---|---|---|
+| Skeptical bear | 15% | $8.20 | $1.23 |
+| Bear | 25% | $20.00 | $5.00 |
+| Base | 45% | $37.00 | $16.65 |
+| Bull | 15% | $69.00 | $10.35 |
+| **Risk-adjusted fair value** | | | **$33.23** |
+
+### What Must Be True for $8 to Be the Right Price
+
+For $8/share to be a fair valuation, you need to believe:
+1. BYSANTI generates essentially zero incremental revenue above Fanapt cannibalization
+2. NEREUS is a commercial failure
+3. Imsidolimab is not approved
+4. HETLIOZ revenue collapses
+5. The company cannot reduce its cost structure despite having proven it can run profitably at lower revenue levels ($64M FCF on ~$200M revenue in 2021)
+
+All five would need to occur simultaneously. That is an extremely pessimistic scenario.
+
+### What Must Be True for $33+ to Be the Right Price
+
+1. BYSANTI achieves $250-350M in peak sales as a differentiated branded product with patent protection to 2044
+2. NEREUS captures a meaningful share of the motion sickness market ($100-200M peak)
+3. Operating margins normalize to 35-40%+ at scale
+4. No dilutive financing is required (cash runway holds)
+
+These are plausible outcomes, not heroic assumptions.
+
+---
+
+## 8. COMPARABLE COMPANY ANALYSIS
+
+| Company | Market Cap | Revenue (TTM) | P/S | Key Drug | Notes |
+|---|---|---|---|---|---|
+| **Supernus (SUPN)** | $2.9B | ~$700M | ~4.1x | Qelbree, GOCOVRI, ZURZUVAE | Multi-product CNS; ~40% op margin target |
+| **ITCI (acquired)** | $14.6B (acq.) | $680M | ~21x trailing | CAPLYTA | Single-product psych; $5B peak potential; J&J premium |
+| **VNDA at $8** | $473M | $216M | **2.2x (P/S)** | Fanapt, BYSANTI, NEREUS, HETLIOZ | Multi-product; 2 fresh approvals; 0.97x EV/Sales |
+| **VNDA at $33** | $1.95B | $216M | 9.0x | -- | Implies significant pipeline value |
+
+At $8/share, VNDA trades at a fraction of SUPN's revenue multiple despite having:
+- Comparable or superior gross margins (~94% vs ~80% for SUPN)
+- Two brand-new approved drugs with patent protection to 2044
+- A $264M net cash position representing 56% of market cap
+- A pipeline (imsidolimab, Fanapt LAI, BYSANTI for MDD) with multiple additional catalysts
+
+The discount is explainable by: (a) execution risk around commercialization, (b) heavy current cash burn, and (c) the market not yet pricing in pipeline revenue. But the magnitude of the discount appears excessive.
+
+---
+
+## 9. KEY FINANCIAL DRIVERS
+
+**The 1-3 metrics that will determine this stock's trajectory:**
+
+### 1. BYSANTI Launch Uptake (Most Critical)
+- BYSANTI is the make-or-break variable. If it achieves $200M+ in peak sales as a differentiated branded product with 2044 patent exclusivity, VNDA's valuation re-rates dramatically.
+- The drug is bioequivalent to iloperidone (Fanapt) but has NCE status, fresh patent protection, and potential for an MDD indication.
+- **Positive inflection:** Fast formulary placement, payer acceptance, first Rx data in Q4 2026/Q1 2027
+- **Negative inflection:** Payer resistance to paying branded pricing for a drug that converts to a generic molecule; slow prescriber adoption
+
+### 2. Cash Burn vs. Revenue Ramp Timing
+- At current burn rates ($120-150M/year), VNDA has ~2 years of runway. Revenue from NEREUS and BYSANTI needs to materially ramp by mid-2027 to avoid dilutive financing.
+- **Positive inflection:** Revenue acceleration reduces net burn; cash position stabilizes above $150M
+- **Negative inflection:** Launch delays, higher-than-expected commercialization costs, cash drops below $100M
+
+### 3. Fanapt Sustainability
+- Fanapt is the engine generating $117M (growing 24%) and is the current revenue backbone. Its trajectory is critical to bridge the gap until BYSANTI/NEREUS generate meaningful revenue.
+- **Positive inflection:** Continued prescription growth in bipolar I; Fanapt LAI approval
+- **Negative inflection:** Generic iloperidone for bipolar I indication; market share loss to CAPLYTA
+
+---
+
+## 10. WHAT CONSENSUS MAY BE MISSING
+
+### The BYSANTI-Fanapt Cannibalization Question Is Overblown
+
+The market's likely concern: "BYSANTI is bioequivalent to iloperidone, which is Fanapt's active ingredient. So BYSANTI just cannibalizes Fanapt, and net-net you get zero incremental revenue."
+
+**Why this is probably wrong:**
+
+1. **Patent lifecycle extension.** Fanapt faces eventual generic erosion (generic iloperidone is already approved for schizophrenia). BYSANTI has NCE status and patent protection to 2044 -- 18 years of branded exclusivity. Even if BYSANTI fully replaces Fanapt over time, it converts a declining-patent revenue stream into one with nearly two decades of protection. This alone justifies significant incremental value.
+
+2. **Label expansion.** Fanapt is approved for bipolar I and schizophrenia. BYSANTI has the same indications plus is in Phase 3 for treatment-resistant MDD -- a far larger market. If the MDD trial succeeds (data expected end of 2026), BYSANTI becomes a multi-indication franchise drug.
+
+3. **The real comp is not Fanapt-to-BYSANTI substitution. The real comp is CAPLYTA.** J&J paid $14.6B for ITCI/CAPLYTA -- a single atypical antipsychotic with $680M revenue and bipolar/schizophrenia/MDD indications. BYSANTI is positioning for the same trifecta. Even at 5-10% of CAPLYTA's valuation, that implies $730M-$1.46B in BYSANTI franchise value alone -- more than VNDA's entire current market cap.
+
+4. **Formulary dynamics.** BYSANTI as an NCE may receive preferred formulary positioning over generic iloperidone in certain plans due to manufacturer rebate programs, whereas Fanapt may lose formulary positioning to generics. The NCE designation creates commercial flexibility that Fanapt lacks.
+
+### The GLP-1 Nausea Option Is Essentially Free in the Stock
+
+Tradipitant (NEREUS active ingredient) showed a 50% reduction in vomiting vs. placebo in a Phase 2 study with Wegovy. The GLP-1 market exceeds $50B. If even 5-10% of GLP-1 patients use tradipitant for GI management, the revenue opportunity dwarfs the motion sickness indication. Phase 3 is planned for H1 2026. This option is worth hundreds of millions in expectation but is essentially unpriced at $8/share because (a) it is early-stage and (b) the market is focused on near-term cash burn.
+
+### The Net Cash Floor
+
+At $8/share, $4.47 of that is cash. The market is pricing the **entire operating business** -- $216M in revenue, two freshly approved drugs, a deep pipeline, and a 300-person commercial infrastructure -- at $3.53/share, or roughly $209M in enterprise value. That is less than one year's current revenue. For a company with 94% gross margins and growing revenue, this is an extremely compressed valuation that only makes sense if you expect permanent value destruction.
+
+---
+
+## 11. CONCLUSION
+
+**At $8/share, VNDA is priced for the deeply skeptical bear case where virtually everything goes wrong.** The market is assigning zero value to BYSANTI, zero value to NEREUS's GLP-1 option, zero value to imsidolimab, and is pricing the existing Fanapt/HETLIOZ/PONVORY business at less than 1x EV/revenue.
+
+The risk-adjusted probability-weighted fair value based on this analysis is approximately **$33/share**, with the primary variance driver being BYSANTI's commercial trajectory.
+
+**Key risks that could justify the low valuation:**
+- Cash burn exceeds estimates and forces a dilutive raise at depressed prices
+- BYSANTI cannot differentiate from generic iloperidone in payers' eyes
+- HETLIOZ collapse accelerates
+- Imsidolimab and NEREUS are commercial disappointments
+
+**Verdict:** Financially solid but in an aggressive investment phase. The balance sheet provides adequate runway under reasonable assumptions. The stock appears materially undervalued relative to the probability-weighted value of its approved and late-stage pipeline, with the existing revenue base providing a meaningful floor. The market is over-discounting execution risk and under-appreciating the patent lifecycle extension that BYSANTI provides.
+
+---
+
+## KEY SOURCES
+
+- [Vanda Pharmaceuticals FY2025 Earnings Release](https://www.prnewswire.com/news-releases/vanda-pharmaceuticals-reports-fourth-quarter-and-full-year-2025-financial-results-302685633.html) (Feb 11, 2026)
+- [Vanda Pharmaceuticals Q3 2025 Earnings Release](https://www.prnewswire.com/news-releases/vanda-pharmaceuticals-reports-third-quarter-2025-financial-results-302598878.html) (Oct 29, 2025)
+- [Vanda Pharmaceuticals FY2024 Earnings Release](https://www.prnewswire.com/news-releases/vanda-pharmaceuticals-reports-fourth-quarter-and-full-year-2024-financial-results-302376529.html) (Feb 13, 2025)
+- [BYSANTI FDA Approval Press Release](https://www.prnewswire.com/news-releases/vanda-pharmaceuticals-announces-fda-approval-of-bysanti-milsaperidone-for-the-treatment-of-bipolar-i-disorder-and-schizophrenia---a-new-chemical-entity-opening-new-horizons-in-psychiatric-innovation-302693941.html) (Feb 20, 2026)
+- [NEREUS FDA Approval Press Release](https://www.prnewswire.com/news-releases/vanda-pharmaceuticals-announces-fda-approval-of-nereus-tradipitant-for-the-prevention-of-vomiting-induced-by-motion-a-historic-scientific-milestone-in-the-prevention-of-motion-sickness-302650965.html) (Dec 30, 2025)
+- [Imsidolimab BLA Submission](https://www.prnewswire.com/news-releases/vanda-announces-submission-of-biologics-license-application-to-the-fda-for-imsidolimab-for-the-treatment-of-generalized-pustular-psoriasis-302641858.html) (Dec 15, 2025)
+- [Q4 2025 Earnings Call Highlights](https://www.dailypolitical.com/2026/02/13/vanda-pharmaceuticals-q4-earnings-call-highlights.html)
+- [J&J / Intra-Cellular Therapies Acquisition](https://www.jnj.com/media-center/press-releases/johnson-johnson-strengthens-neuroscience-leadership-with-acquisition-of-intra-cellular-therapies-inc)
+- [Supernus Pharmaceuticals Q3 2025 Results](https://www.stocktitan.net/news/SUPN/supernus-announces-third-quarter-2025-financial-byqja9eygru3.html)
+- Yahoo Finance VNDA cash flow data (historical)
+- Analyst estimates: HC Wainwright ($22 PT), B. Riley ($14 PT), Jefferies ($7.50 PT)
+- Consensus estimates per MarketBeat/StockAnalysis (avg PT $13.63)
+
+---
+
+## DATA QUALITY DISCLAIMERS
+
+1. **SBC expense:** Specific annual SBC figures were not available from public search results. Estimated at $10-15M based on unrecognized compensation costs disclosed in Q3 2025 10-Q (~$15M remaining as of Sept 30, 2025). The 10-K filing would contain exact figures.
+2. **FY2025 operating cash flow:** Estimated from the $110.8M decline in cash/securities. The precise figure requires the FY2025 10-K cash flow statement.
+3. **Q1/Q2 2025 quarterly revenue by product:** Q1 and Q2 breakdowns estimated from nine-month totals minus Q3. Full precision requires individual quarterly 10-Q filings.
+4. **BYSANTI pricing:** Not yet disclosed. Revenue estimates assume pricing in line with or at a modest premium to Fanapt WAC (~$10-13K/patient/year).
+5. **NEREUS pricing:** Pricing referenced as $200-600/dose range for NK-1 class products per management commentary on earnings call. Final pricing not set.
+6. **Forward revenue estimates for BYSANTI and NEREUS are assumptions, not consensus forecasts.** These are the author's estimates based on addressable market size, comparable drug launches, and management commentary.


### PR DESCRIPTION
Initial specialist agent outputs for VNDA (Vanda Pharmaceuticals)
FDA approval catalyst analysis pipeline.

https://claude.ai/code/session_01YFujW8v1hz4EwX6LerYSh6